### PR TITLE
Fix slug sanitization, automatic permalink flushing, and PHP 8.1+ com…

### DIFF
--- a/Admin/MPWPB_Quick_Setup.php
+++ b/Admin/MPWPB_Quick_Setup.php
@@ -92,19 +92,28 @@
                         </script>
 						<?php
 					}
-					if (isset($_POST['finish_quick_setup'])) {
-						$label = isset($_POST['mpwpb_label']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_label'])) : 'service-booking-manager';
-						$slug = isset($_POST['mpwpb_slug']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_slug'])) : 'service-booking-manager';
-						$general_settings_data = get_option('mpwpb_general_settings');
-						$update_general_settings_arr = [
-							'label' => $label,
-							'slug' => $slug
-						];
-						$new_general_settings_data = is_array($general_settings_data) ? array_replace($general_settings_data, $update_general_settings_arr) : $update_general_settings_arr;
-						update_option('mpwpb_general_settings', $new_general_settings_data);
-						flush_rewrite_rules();
-						wp_redirect(admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_list'));
+				if (isset($_POST['finish_quick_setup'])) {
+					$label = isset($_POST['mpwpb_label']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_label'])) : 'service-booking-manager';
+					$slug = isset($_POST['mpwpb_slug']) ? sanitize_title(wp_unslash($_POST['mpwpb_slug'])) : 'service-booking';
+					$general_settings_data = get_option('mpwpb_general_settings');
+					$update_general_settings_arr = [
+						'label' => $label,
+						'slug' => $slug
+					];
+					$new_general_settings_data = is_array($general_settings_data) ? array_replace($general_settings_data, $update_general_settings_arr) : $update_general_settings_arr;
+					update_option('mpwpb_general_settings', $new_general_settings_data);
+					
+					// Re-register post type with new slug before flushing rewrite rules
+					if (class_exists('MPWPB_CPT')) {
+						MPWPB_CPT::register_service_post_type();
 					}
+					
+					// Flush rewrite rules to apply the new slug
+					flush_rewrite_rules(false);
+					
+					wp_redirect(admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_list'));
+					exit;
+				}
 				}
 				?>
                 <div class="mpStyle mpwpb_style mep-quick-setup">

--- a/templates/registration/date_time_select.php
+++ b/templates/registration/date_time_select.php
@@ -74,12 +74,18 @@
             <div class="" >
                 <div class="owl-theme mpwpb-owl-carousel" id="mpwpb_datetime_holder1">
                     <?php if (sizeof($all_dates) > 0) {
-                        wp_kses_post( MPWPB_Details_Layout::display_booking_date( $post_id, $all_dates ) );
+                        $booking_date_output = MPWPB_Details_Layout::display_booking_date( $post_id, $all_dates );
+                        if ( $booking_date_output !== null ) {
+                            echo wp_kses_post( $booking_date_output );
+                        }
                     ?>
                 </div>
                 <div class="mpwpb_select_time_holder" id="<?php echo esc_attr( $post_id );?>">
                     <?php
-                        wp_kses_post( MPWPB_Details_Layout::display_booking_time( $post_id, $all_dates ) );
+                        $booking_time_output = MPWPB_Details_Layout::display_booking_time( $post_id, $all_dates );
+                        if ( $booking_time_output !== null ) {
+                            echo wp_kses_post( $booking_time_output );
+                        }
                     ?>
                 </div>
                 <?php


### PR DESCRIPTION
…patibility

ISSUES FIXED:

1. Slug Sanitization in Quick Setup
   - Changed from sanitize_text_field() to sanitize_title() to properly convert custom text (including spaces) to URL-friendly slugs
   - Example: 'My Service' now becomes 'my-service' automatically
   - Affected file: Admin/MPWPB_Quick_Setup.php

2. Automatic Permalink Flushing
   - Fixed issue where permalinks required manual flush after slug changes
   - Added automatic post type re-registration and rewrite rule flushing when:
     * Slug is changed in Quick Setup
     * Slug is changed in Global Settings * New service is published
   - Removed need for manual Settings > Permalinks > Save
   - Affected files:
     * Admin/MPWPB_CPT.php - Added register_service_post_type() static method
     * Admin/MPWPB_Quick_Setup.php - Added post type re-registration before flush * Admin/MPWPB_Settings_Global.php - Added hooks for automatic flushing

3. PHP 8.1+ Deprecation Warnings
   - Fixed null value passed to wp_kses_post() causing preg_replace() deprecation
   - Added null checks before calling wp_kses_post()
   - Prevents PHP 8.1+ deprecation warnings in error logs
   - Affected file: templates/registration/date_time_select.php

TECHNICAL CHANGES:

- MPWPB_CPT.php:
  * Extracted post type registration to static register_service_post_type() method
  * Added flush_rewrite_on_service_publish() hook for new service publications
  * Added maybe_flush_rewrite_rules() to handle deferred rewrite flushing
  * Fixed rewrite array to include 'with_front' => false

- MPWPB_Quick_Setup.php:
  * Changed slug sanitization from sanitize_text_field() to sanitize_title()
  * Added post type re-registration before flushing rewrite rules
  * Added exit after redirect for better practice

- MPWPB_Settings_Global.php:
  * Added pre_update_option filter to sanitize slug field
  * Added updated_option hook to detect slug changes
  * Automatically re-registers post type and flushes rules on slug change
  * Updated field description to indicate automatic sanitization

- date_time_select.php:
  * Added null checks before wp_kses_post() calls
  * Prevents PHP 8.1+ deprecation warnings
  * Ensures safe output when methods return null

All changes follow WordPress coding standards and plugin structure patterns.