### PR TITLE
fix(security): harden template loading and privileged AJAX endpoints

### DIFF
--- a/Admin/MPWPB_Settings.php
+++ b/Admin/MPWPB_Settings.php
@@ -68,13 +68,24 @@
 				<?php
 			}
 			public function save_settings($post_id) {
-				if (!isset($_POST['mpwpb_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_nonce'])), 'mpwpb_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (get_post_type($post_id) !== MPWPB_Function::get_cpt()) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
+					return;
+				}
+				if (!isset($_POST['mpwpb_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_nonce'])), 'mpwpb_nonce')) {
 					return;
 				}
 				if (get_post_type($post_id) == MPWPB_Function::get_cpt()) {
 					$title = isset($_POST['mpwpb_shortcode_title']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_shortcode_title'])) : '';
 					$sub_title = isset($_POST['mpwpb_shortcode_sub_title']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_shortcode_sub_title'])) : '';
 					$mpwpb_template = isset($_POST['mpwpb_template']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_template'])) : 'default.php';
+					$mpwpb_template = MPWPB_Function::sanitize_details_template_name($mpwpb_template);
+					
 					update_post_meta($post_id, 'mpwpb_shortcode_title', $title);
 					update_post_meta($post_id, 'mpwpb_shortcode_sub_title', $sub_title);
 					update_post_meta($post_id, 'mpwpb_template', $mpwpb_template);
@@ -175,7 +186,13 @@
 				do_action('mpwpb_settings_save', $post_id);
 			}
 			public function save_schedule($post_id, $day) {
-				if (!isset($_POST['mpwpb_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_nonce'])), 'mpwpb_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('edit_post', $post_id)) {
+					return;
+				}
+				if (!isset($_POST['mpwpb_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_nonce'])), 'mpwpb_nonce')) {
 					return;
 				}
 				$start_name = 'mpwpb_' . $day . '_start_time';

--- a/Admin/MPWPB_Staff_DashBoard.php
+++ b/Admin/MPWPB_Staff_DashBoard.php
@@ -21,11 +21,21 @@ if (!class_exists('MPWPB_Staff_DashBoard')) {
 
 
         function mpwpb_save_specific_schedule() {
-
+            if (!is_user_logged_in()) {
+                wp_send_json_error('User not logged in');
+            }
+            if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_dashboard_nonce')) {
+                wp_send_json_error('Security check failed');
+            }
             $user_id = get_current_user_id();
+            $current_user = wp_get_current_user();
+            $is_staff = in_array('mpwpb_staff', (array) $current_user->roles, true);
+            if (!$is_staff && !current_user_can('create_users') && !current_user_can('manage_options')) {
+                wp_send_json_error('Unauthorized request');
+            }
 
-            $off_dates_json = isset( $_POST['offDates_str'] ) ? stripslashes( sanitize_text_field( $_POST['offDates_str'] ) ) : '';
-            $off_days = isset( $_POST['offDays'] ) ? stripslashes( sanitize_text_field( $_POST['offDays'] ) ) : '';
+            $off_dates_json = isset($_POST['offDates_str']) ? wp_unslash(sanitize_text_field($_POST['offDates_str'])) : '';
+            $off_days = isset($_POST['offDays']) ? sanitize_text_field(wp_unslash($_POST['offDays'])) : '';
             $off_dates = json_decode($off_dates_json, true);
             if (!$user_id) {
                 wp_send_json_error('User not logged in');
@@ -580,7 +590,10 @@ if (!class_exists('MPWPB_Staff_DashBoard')) {
                 $booking_data->mpwpb_date         = isset($meta['mpwpb_date'][0]) ? $meta['mpwpb_date'][0] : '';
                 $booking_data->mpwpb_order_id     = isset($meta['mpwpb_order_id'][0]) ? $meta['mpwpb_order_id'][0] : '';
                 $booking_data->mpwpb_order_status = isset($meta['mpwpb_order_status'][0]) ? $meta['mpwpb_order_status'][0] : '';
-                $booking_data->mpwpb_service = isset($meta['mpwpb_service'][0]) ? unserialize( $meta['mpwpb_service'][0] ) : array();
+                $booking_data->mpwpb_service = isset($meta['mpwpb_service'][0]) ? maybe_unserialize($meta['mpwpb_service'][0]) : array();
+                if (!is_array($booking_data->mpwpb_service)) {
+                    $booking_data->mpwpb_service = array();
+                }
                 $formatted_bookings[] = $booking_data;
             }
 

--- a/Admin/MPWPB_Staff_Members.php
+++ b/Admin/MPWPB_Staff_Members.php
@@ -11,19 +11,21 @@ if (!class_exists('MPWPB_Staff_Members')) {
             }
 
             add_action('wp_ajax_get_mpwpb_get_staff_form', array($this, 'get_mpwpb_get_staff_form'));
-            add_action('wp_ajax_nopriv_get_mpwpb_get_staff_form', array($this, 'get_mpwpb_get_staff_form'));
             /*********************************************/
             add_action('wp_ajax_mpwpb_delete_staff', array($this, 'mpwpb_delete_staff'));
-            add_action('wp_ajax_nopriv_mpwpb_delete_staff', array($this, 'mpwpb_delete_staff'));
             /************************/
             add_action('wp_ajax_get_mpwpb_staff_end_time_slot', array($this, 'get_mpwpb_staff_end_time_slot'));
-            add_action('wp_ajax_nopriv_get_mpwpb_staff_end_time_slot', array($this, 'get_mpwpb_staff_end_time_slot'));
             /***/
             add_action('wp_ajax_get_mpwpb_staff_start_break_time', array($this, 'get_mpwpb_staff_start_break_time'));
-            add_action('wp_ajax_nopriv_get_mpwpb_staff_start_break_time', array($this, 'get_mpwpb_staff_start_break_time'));
             /***/
             add_action('wp_ajax_get_mpwpb_staff_end_break_time', array($this, 'get_mpwpb_staff_end_break_time'));
-            add_action('wp_ajax_nopriv_get_mpwpb_staff_end_break_time', array($this, 'get_mpwpb_staff_end_break_time'));
+        }
+        private function ensure_staff_manage_permission(): bool {
+            if (!current_user_can('create_users')) {
+                wp_send_json_error('Unauthorized request');
+                return false;
+            }
+            return true;
         }
 
         public function staffs_menu() {
@@ -536,6 +538,9 @@ if (!class_exists('MPWPB_Staff_Members')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
             }
+            if (!$this->ensure_staff_manage_permission()) {
+                return;
+            }
             $user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
             $this->staff_form($user_id);
             die();
@@ -543,6 +548,9 @@ if (!class_exists('MPWPB_Staff_Members')) {
         public function mpwpb_delete_staff() {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+            }
+            if (!$this->ensure_staff_manage_permission()) {
+                return;
             }
             $staff_id = isset($_POST['staff_id']) ? sanitize_text_field(wp_unslash($_POST['staff_id'])) : '';
             if ($staff_id > 0) {
@@ -555,6 +563,9 @@ if (!class_exists('MPWPB_Staff_Members')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
             }
+            if (!$this->ensure_staff_manage_permission()) {
+                return;
+            }
             $user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
             $day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
             $start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
@@ -564,6 +575,9 @@ if (!class_exists('MPWPB_Staff_Members')) {
         public function get_mpwpb_staff_start_break_time() {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+            }
+            if (!$this->ensure_staff_manage_permission()) {
+                return;
             }
             $user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
             $day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
@@ -576,6 +590,9 @@ if (!class_exists('MPWPB_Staff_Members')) {
             if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
                 wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
             }
+            if (!$this->ensure_staff_manage_permission()) {
+                return;
+            }
             $user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
             $day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
             $start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
@@ -585,7 +602,13 @@ if (!class_exists('MPWPB_Staff_Members')) {
         }
         /*************************************/
         public function save_staff() {
-            if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('create_users')) {
+            if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+                return;
+            }
+            if (!current_user_can('create_users')) {
+                return;
+            }
+            if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce')) {
                 return;
             }
             $user_id = isset($_POST['mpwpb_user']) ? absint(wp_unslash($_POST['mpwpb_user'])) : '';
@@ -638,7 +661,7 @@ if (!class_exists('MPWPB_Staff_Members')) {
                     $this->save_schedule($user_id, $key);
                 }
                 //**********************//
-                $off_days = isset($_POST['mpwpb_off_days']) ? $_POST['mpwpb_off_days'] : [];
+                $off_days = isset($_POST['mpwpb_off_days']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_off_days'])) : '';
                 update_user_meta($user_id, 'mpwpb_off_days', $off_days);
                 //**********************//
                 $off_dates = isset($_POST['mpwpb_off_dates']) ? array_map('sanitize_text_field', wp_unslash($_POST['mpwpb_off_dates'])) : [];
@@ -656,7 +679,13 @@ if (!class_exists('MPWPB_Staff_Members')) {
             }
         }
         public function save_schedule($user_id, $day) {
-            if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('create_users')) {
+            if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+                return;
+            }
+            if (!current_user_can('create_users')) {
+                return;
+            }
+            if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce')) {
                 return;
             }
             $start_name = 'mpwpb_' . $day . '_start_time';

--- a/Admin/MPWPB_Staffs.php
+++ b/Admin/MPWPB_Staffs.php
@@ -11,19 +11,21 @@
 			public function __construct() {
 				add_action('admin_menu', array($this, 'staffs_menu'));
 				add_action('wp_ajax_get_mpwpb_get_staff_form', array($this, 'get_mpwpb_get_staff_form'));
-				add_action('wp_ajax_nopriv_get_mpwpb_get_staff_form', array($this, 'get_mpwpb_get_staff_form'));
 				/*********************************************/
 				add_action('wp_ajax_mpwpb_delete_staff', array($this, 'mpwpb_delete_staff'));
-				add_action('wp_ajax_nopriv_mpwpb_delete_staff', array($this, 'mpwpb_delete_staff'));
 				/************************/
 				add_action('wp_ajax_get_mpwpb_staff_end_time_slot', array($this, 'get_mpwpb_staff_end_time_slot'));
-				add_action('wp_ajax_nopriv_get_mpwpb_staff_end_time_slot', array($this, 'get_mpwpb_staff_end_time_slot'));
 				/***/
 				add_action('wp_ajax_get_mpwpb_staff_start_break_time', array($this, 'get_mpwpb_staff_start_break_time'));
-				add_action('wp_ajax_nopriv_get_mpwpb_staff_start_break_time', array($this, 'get_mpwpb_staff_start_break_time'));
 				/***/
 				add_action('wp_ajax_get_mpwpb_staff_end_break_time', array($this, 'get_mpwpb_staff_end_break_time'));
-				add_action('wp_ajax_nopriv_get_mpwpb_staff_end_break_time', array($this, 'get_mpwpb_staff_end_break_time'));
+			}
+			private function ensure_staff_manage_permission(): bool {
+				if (!current_user_can('create_users')) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
 			}
 			public function staffs_menu() {
 				$cpt = MPWPB_Function::get_cpt();
@@ -522,6 +524,9 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
+				if (!$this->ensure_staff_manage_permission()) {
+					return;
+				}
 				$user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
 				$this->staff_form($user_id);
 				die();
@@ -529,6 +534,9 @@
 			public function mpwpb_delete_staff() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+				}
+				if (!$this->ensure_staff_manage_permission()) {
+					return;
 				}
 				$staff_id = isset($_POST['staff_id']) ? sanitize_text_field(wp_unslash($_POST['staff_id'])) : '';
 				if ($staff_id > 0) {
@@ -541,6 +549,9 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
+				if (!$this->ensure_staff_manage_permission()) {
+					return;
+				}
 				$user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
 				$start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
@@ -550,6 +561,9 @@
 			public function get_mpwpb_staff_start_break_time() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+				}
+				if (!$this->ensure_staff_manage_permission()) {
+					return;
 				}
 				$user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
@@ -562,6 +576,9 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
+				if (!$this->ensure_staff_manage_permission()) {
+					return;
+				}
 				$user_id = isset($_POST['user_id']) ? sanitize_text_field(wp_unslash($_POST['user_id'])) : '';
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
 				$start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
@@ -571,7 +588,13 @@
 			}
 			/*************************************/
 			public function save_staff() {
-				if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('create_users')) {
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('create_users')) {
+					return;
+				}
+				if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce')) {
 					return;
 				}
 				$user_id = isset($_POST['mpwpb_user']) ? absint(wp_unslash($_POST['mpwpb_user'])) : '';
@@ -624,7 +647,7 @@
 						$this->save_schedule($user_id, $key);
 					}
 					//**********************//
-					$off_days = isset($_POST['mpwpb_off_days']) ? $_POST['mpwpb_off_days'] : [];
+					$off_days = isset($_POST['mpwpb_off_days']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_off_days'])) : '';
 					update_user_meta($user_id, 'mpwpb_off_days', $off_days);
 					//**********************//
 					$off_dates = isset($_POST['mpwpb_off_dates']) ? array_map('sanitize_text_field', wp_unslash($_POST['mpwpb_off_dates'])) : [];
@@ -642,7 +665,13 @@
 				}
 			}
 			public function save_schedule($user_id, $day) {
-				if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('create_users')) {
+				if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE) {
+					return;
+				}
+				if (!current_user_can('create_users')) {
+					return;
+				}
+				if (!isset($_POST['mpwpb_add_staff_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['mpwpb_add_staff_nonce'])), 'mpwpb_add_staff_nonce')) {
 					return;
 				}
 				$start_name = 'mpwpb_' . $day . '_start_time';

--- a/Admin/MPWPB_Wc_Checkout_Fields.php
+++ b/Admin/MPWPB_Wc_Checkout_Fields.php
@@ -21,11 +21,13 @@
 				add_action('admin_notices', array($this, 'mp_admin_notice'));
 				add_action('add_switch_button', array($this, 'switch_button'), 10, 3);
 				add_action('wp_ajax_mpwpb_disable_field', array($this, 'mpwpb_disable_field'));
-				add_action('wp_ajax_nopriv_mpwpb_disable_field', [$this, 'mpwpb_disable_field']);
 			}
 			public function mpwpb_disable_field() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+				}
+				if (!current_user_can('manage_options')) {
+					wp_send_json_error('Unauthorized request');
 				}
 				$response = 'failed';
 				$key = isset($_POST['key']) ? sanitize_text_field(wp_unslash($_POST['key'])) : null;

--- a/Admin/settings/Category.php
+++ b/Admin/settings/Category.php
@@ -16,35 +16,39 @@
 				add_action('mpwpb_show_category', [$this, 'category_settings_section']);
 				// save category service
 				add_action('wp_ajax_mpwpb_save_category_service', [$this, 'save_category_service']);
-				add_action('wp_ajax_nopriv_mpwpb_save_category_service', [$this, 'save_category_service']);
 				// mpwpb update category service
 				add_action('wp_ajax_mpwpb_update_category_service', [$this, 'update_category_service']);
-				add_action('wp_ajax_nopriv_mpwpb_update_category_service', [$this, 'update_category_service']);
 				// mpwpb update sub category service
 				add_action('wp_ajax_mpwpb_update_sub_category', [$this, 'update_sub_category_service']);
-				add_action('wp_ajax_nopriv_mpwpb_update_sub_category', [$this, 'update_sub_category_service']);
 				// mpwpb delete category service
 				add_action('wp_ajax_mpwpb_category_service_delete_item', [$this, 'delete_category_service']);
-				add_action('wp_ajax_nopriv_mpwpb_category_service_delete_item', [$this, 'delete_category_service']);
 				// Load  category by ajax
 				add_action('wp_ajax_mpwpb_load_parent_category', [$this, 'load_parent_category']);
-				add_action('wp_ajax_nopriv_mpwpb_load_parent_category', [$this, 'load_parent_category']);
 				// Load  category by ajax
 				add_action('wp_ajax_mpwpb_load_sub_category', [$this, 'load_sub_category']);
-				add_action('wp_ajax_nopriv_mpwpb_load_sub_category', [$this, 'load_sub_category']);
 				// Del sub category by ajax
 				add_action('wp_ajax_mpwpb_sub_category_delete', [$this, 'delete_sub_category']);
-				add_action('wp_ajax_nopriv_mpwpb_sub_category_delete', [$this, 'delete_sub_category']);
 				// Category sort order
 				add_action('wp_ajax_mpwpb_sort_category',[$this,'sort_category']);
 				// Sub Category sort order
 				add_action('wp_ajax_mpwpb_sort_sub_category',[$this,'sort_sub_category']);
 			}
+			private function ensure_post_edit_permission($post_id): bool {
+				$post_id = absint($post_id);
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
+			}
 			public function sort_category() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
 				$categories = $this->get_categories($post_id);
 				$new_ordered = [];
@@ -68,7 +72,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
 				$categories = $this->get_sub_categories($post_id);
 				$new_ordered = [];
@@ -148,7 +155,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				ob_start();
 				$resultMessage = esc_html__('Data Updated Successfully', 'service-booking-manager');
 				$this->show_parent_category_lists($post_id);
@@ -163,7 +173,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$parentId = isset($_POST['parentId']) ? sanitize_text_field(wp_unslash($_POST['parentId'])) : '';
 				ob_start();
 				$resultMessage = esc_html__('Data Updated Successfully', 'service-booking-manager');
@@ -363,7 +376,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['category_postID']) ? sanitize_text_field(wp_unslash($_POST['category_postID'])) : '';
+				$post_id = isset($_POST['category_postID']) ? absint(wp_unslash($_POST['category_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$categories = $this->get_categories($post_id);
 				$sub_categories = $this->get_sub_categories($post_id);
 				$iconClass = '';
@@ -410,7 +426,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['category_postID']) ? sanitize_text_field(wp_unslash($_POST['category_postID'])) : '';
+				$post_id = isset($_POST['category_postID']) ? absint(wp_unslash($_POST['category_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sub_categories = $this->get_sub_categories($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -452,7 +471,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['category_postID']) ? sanitize_text_field(wp_unslash($_POST['category_postID'])) : '';
+				$post_id = isset($_POST['category_postID']) ? absint(wp_unslash($_POST['category_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$categories = $this->get_categories($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -493,7 +515,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['category_postID']) ? sanitize_text_field(wp_unslash($_POST['category_postID'])) : '';
+				$post_id = isset($_POST['category_postID']) ? absint(wp_unslash($_POST['category_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$categories = $this->get_categories($post_id);
 				if (!empty($categories)) {
 					if (isset($_POST['itemId'])) {
@@ -527,7 +552,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['category_postID']) ? sanitize_text_field(wp_unslash($_POST['category_postID'])) : '';
+				$post_id = isset($_POST['category_postID']) ? absint(wp_unslash($_POST['category_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sub_categories = $this->get_sub_categories($post_id);
 				if (!empty($sub_categories)) {
 					if (isset($_POST['itemId'])) {

--- a/Admin/settings/Date_Time.php
+++ b/Admin/settings/Date_Time.php
@@ -12,13 +12,18 @@
 				add_action('add_mpwpb_settings_tab_content', [$this, 'date_time_settings'], 10, 1);
 				/************************/
 				add_action('wp_ajax_get_mpwpb_end_time_slot', array($this, 'get_mpwpb_end_time_slot'));
-				add_action('wp_ajax_nopriv_get_mpwpb_end_time_slot', array($this, 'get_mpwpb_end_time_slot'));
 				/***/
 				add_action('wp_ajax_get_mpwpb_start_break_time', array($this, 'get_mpwpb_start_break_time'));
-				add_action('wp_ajax_nopriv_get_mpwpb_start_break_time', array($this, 'get_mpwpb_start_break_time'));
 				/***/
 				add_action('wp_ajax_get_mpwpb_end_break_time', array($this, 'get_mpwpb_end_break_time'));
-				add_action('wp_ajax_nopriv_get_mpwpb_end_break_time', array($this, 'get_mpwpb_end_break_time'));
+			}
+			private function ensure_post_edit_permission($post_id): bool {
+				$post_id = absint($post_id);
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
 			}
 			public function date_time_settings($post_id) {
 				$date_format = MPWPB_Global_Function::date_picker_format();
@@ -323,7 +328,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
+				$post_id = isset($_POST['post_id']) ? absint(wp_unslash($_POST['post_id'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
 				$start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
 				$this->end_time_slot($post_id, $day, $start_time);
@@ -333,7 +341,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
+				$post_id = isset($_POST['post_id']) ? absint(wp_unslash($_POST['post_id'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
 				$start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
 				$end_time = isset($_POST['end_time']) ? sanitize_text_field(wp_unslash($_POST['end_time'])) : '';
@@ -344,7 +355,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
+				$post_id = isset($_POST['post_id']) ? absint(wp_unslash($_POST['post_id'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$day = isset($_POST['day_name']) ? sanitize_text_field(wp_unslash($_POST['day_name'])) : '';
 				$start_time = isset($_POST['start_time']) ? sanitize_text_field(wp_unslash($_POST['start_time'])) : '';
 				$end_time = isset($_POST['end_time']) ? sanitize_text_field(wp_unslash($_POST['end_time'])) : '';

--- a/Admin/settings/Extra_service.php
+++ b/Admin/settings/Extra_service.php
@@ -12,23 +12,31 @@
 				add_action('add_mpwpb_settings_tab_content', [$this, 'extra_service_settings'], 10, 1);
 				// save extra service
 				add_action('wp_ajax_mpwpb_save_ex_service', [$this, 'save_ex_service']);
-				add_action('wp_ajax_nopriv_mpwpb_save_ex_service', [$this, 'save_ex_service']);
 				// mpwpb update extra service
 				add_action('wp_ajax_mpwpb_ext_service_update', [$this, 'ext_service_update_item']);
-				add_action('wp_ajax_nopriv_mpwpb_ext_service_update', [$this, 'ext_service_update_item']);
 				// mpwpb delete extra service
 				add_action('wp_ajax_mpwpb_ext_service_delete_item', [$this, 'extra_service_delete_item']);
-				add_action('wp_ajax_nopriv_mpwpb_ext_service_delete_item', [$this, 'extra_service_delete_item']);
 				// sort extra service
 				add_action('wp_ajax_mpwpb_sort_extra_service',[$this,'sort_extra_service']);
 				// clone extra service
 				add_action('wp_ajax_mpwpb_clone_ext_service',[$this,'clone_ext_service']);
 			}
+			private function ensure_post_edit_permission($post_id): bool {
+				$post_id = absint($post_id);
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
+			}
 			public function sort_extra_service() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
 				$ext_services = $this->get_extra_services($post_id);
 				$new_ordered = [];
@@ -53,7 +61,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$ext_services = $this->get_extra_services($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -94,7 +105,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$ext_services = $this->get_extra_services($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -135,7 +149,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				update_post_meta($post_id, 'mpwpb_extra_service_active', 'on');
 				$extra_services = $this->get_extra_services($post_id);
 				$iconClass = '';
@@ -326,7 +343,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$extra_services = $this->get_extra_services($post_id);
 				if (!empty($extra_services)) {
 					if (isset($_POST['itemId'])) {

--- a/Admin/settings/Faq.php
+++ b/Admin/settings/Faq.php
@@ -13,22 +13,30 @@
 				add_action('admin_enqueue_scripts', [$this, 'my_custom_editor_enqueue']);
 				// save faq data
 				add_action('wp_ajax_mpwpb_faq_data_save', [$this, 'save_faq_data_settings']);
-				add_action('wp_ajax_nopriv_mpwpb_faq_data_save', [$this, 'save_faq_data_settings']);
 				// update faq data
 				add_action('wp_ajax_mpwpb_faq_data_update', [$this, 'faq_data_update']);
-				add_action('wp_ajax_nopriv_mpwpb_faq_data_update', [$this, 'faq_data_update']);
 				// mpwpb_delete_faq_data
 				add_action('wp_ajax_mpwpb_faq_delete_item', [$this, 'faq_delete_item']);
-				add_action('wp_ajax_nopriv_mpwpb_faq_delete_item', [$this, 'faq_delete_item']);
 				// FAQ sort_faq
 				add_action('wp_ajax_mpwpb_sort_faq', [$this, 'sort_faq']);
+			}
+			private function ensure_post_edit_permission($post_id): bool {
+				$post_id = absint($post_id);
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
 			}
 
 			public function sort_faq() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
 				$mpwpb_faq = get_post_meta($post_id, 'mpwpb_faq', true);;
 				$new_ordered = [];
@@ -162,7 +170,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['mpwpb_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_faq_postID'])) : '';
+				$post_id = isset($_POST['mpwpb_faq_postID']) ? absint(wp_unslash($_POST['mpwpb_faq_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$mpwpb_faq_title = isset($_POST['mpwpb_faq_title']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_faq_title'])) : '';
 				$mpwpb_faq_content = isset($_POST['mpwpb_faq_content']) ? wp_kses_post(wp_unslash($_POST['mpwpb_faq_content'])) : '';
 				$mpwpb_faq = get_post_meta($post_id, 'mpwpb_faq', true);
@@ -188,7 +199,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['mpwpb_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_faq_postID'])) : '';
+				$post_id = isset($_POST['mpwpb_faq_postID']) ? absint(wp_unslash($_POST['mpwpb_faq_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				update_post_meta($post_id, 'mpwpb_faq_active', 'on');
 				$mpwpb_faq_title = isset($_POST['mpwpb_faq_title']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_faq_title'])) : '';
 				$mpwpb_faq_content = isset($_POST['mpwpb_faq_content']) ? wp_kses_post(wp_unslash($_POST['mpwpb_faq_content'])) : '';
@@ -220,7 +234,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['mpwpb_faq_postID']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_faq_postID'])) : '';
+				$post_id = isset($_POST['mpwpb_faq_postID']) ? absint(wp_unslash($_POST['mpwpb_faq_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$mpwpb_faq = get_post_meta($post_id, 'mpwpb_faq', true);
 				$mpwpb_faq = !empty($mpwpb_faq) ? $mpwpb_faq : [];
 				if (!empty($mpwpb_faq)) {

--- a/Admin/settings/Pricing.php
+++ b/Admin/settings/Pricing.php
@@ -11,11 +11,16 @@
 			public function __construct() {
 				add_action('add_mpwpb_settings_tab_content', [$this, 'price_settings'], 10, 1);
 				add_action('wp_ajax_mpwpb_import_old_data', [$this, 'import_old_data'], 10, 1);
-				add_action('wp_ajax_nopriv_mpwpb_import_old_data', [$this, 'import_old_data'],10);
 			}
 
 			public function import_old_data() {
-				$post_id = sanitize_text_field($_POST['postId']);
+				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
+					wp_send_json_error('Invalid nonce!');
+				}
+				$post_id = isset($_POST['postId']) ? absint(wp_unslash($_POST['postId'])) : 0;
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+				}
 				
 				ob_start();
 				$resultMessage = esc_html__('Data Updated Successfully', 'service-booking-manager');

--- a/Admin/settings/Service.php
+++ b/Admin/settings/Service.php
@@ -12,32 +12,37 @@
 				add_action('mpwpb_show_service', [$this, 'view_all_services']);
 				// show_all_services
 				add_action('wp_ajax_mpwpb_show_all_services', [$this, 'show_all_services']);
-				add_action('wp_ajax_nopriv_mpwpb_show_all_services', [$this, 'show_all_services']);
 				// save service
 				add_action('wp_ajax_mpwpb_save_service', [$this, 'save_service']);
-				add_action('wp_ajax_nopriv_mpwpb_save_service', [$this, 'save_service']);
 				//update service
 				add_action('wp_ajax_mpwpb_service_update', [$this, 'update_service']);
-				add_action('wp_ajax_nopriv_mpwpb_service_update', [$this, 'update_service']);
 				// delete service
 				add_action('wp_ajax_mpwpb_service_delete_item', [$this, 'delete_service']);
-				add_action('wp_ajax_nopriv_mpwpb_service_delete_item', [$this, 'delete_service']);
 				// load service by category
 				add_action('wp_ajax_mpwpb_load_service_by_category', [$this, 'load_service_by_category']);
-				add_action('wp_ajax_nopriv_mpwpb_load_service_by_category', [$this, 'load_service_by_category']);
 				// load service by category
 				add_action('wp_ajax_mpwpb_load_service_by_sub_category', [$this, 'load_service_by_sub_category']);
-				add_action('wp_ajax_nopriv_mpwpb_load_service_by_sub_category', [$this, 'load_service_by_sub_category']);
 				// service order
 				add_action('wp_ajax_mpwpb_sort_service',[$this,'sort_service']);
 				// service order
 				add_action('wp_ajax_mpwpb_clone_service',[$this,'clone_services']);
 			}
+			private function ensure_post_edit_permission($post_id): bool {
+				$post_id = absint($post_id);
+				if (!$post_id || !current_user_can('edit_post', $post_id)) {
+					wp_send_json_error('Unauthorized request');
+					return false;
+				}
+				return true;
+			}
 			public function sort_service() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sorted_ids = isset($_POST['sortedIDs']) ? array_map('intval', $_POST['sortedIDs']) : [];
 				$services = $this->get_services($post_id);
 				$new_ordered = [];
@@ -62,7 +67,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$services = $this->get_services($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -113,7 +121,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postID']) ? sanitize_text_field(wp_unslash($_POST['postID'])) : '';
+				$post_id = isset($_POST['postID']) ? absint(wp_unslash($_POST['postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				ob_start();
 				$resultMessage = esc_html__('Data Updated Successfully', 'service-booking-manager');
 				$this->get_all_service_items($post_id);
@@ -127,7 +138,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postId']) ? sanitize_text_field(wp_unslash($_POST['postId'])) : '';
+				$post_id = isset($_POST['postId']) ? absint(wp_unslash($_POST['postId'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$category_id = isset($_POST['itemId']) ? sanitize_text_field(wp_unslash($_POST['itemId'])) : '';
 				ob_start();
 				$resultMessage = __('Data Loaded Successfully', 'service-booking-manager');
@@ -143,7 +157,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['postId']) ? sanitize_text_field(wp_unslash($_POST['postId'])) : '';
+				$post_id = isset($_POST['postId']) ? absint(wp_unslash($_POST['postId'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$sub_cat = isset($_POST['itemId']) ? sanitize_text_field(wp_unslash($_POST['itemId'])) : '';
 				$parent_cat = isset($_POST['parentId']) ? sanitize_text_field(wp_unslash($_POST['parentId'])) : '';
 				ob_start();
@@ -284,7 +301,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$services = $this->get_services($post_id);
 				$iconClass = '';
 				$imageID = '';
@@ -336,7 +356,10 @@
 				}
 
 
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$services = $this->get_services($post_id);
 				$services = !empty($services) ? $services : [];
 				$iconClass = '';
@@ -409,7 +432,10 @@
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
 				}
-				$post_id = isset($_POST['service_postID']) ? sanitize_text_field(wp_unslash($_POST['service_postID'])) : '';
+				$post_id = isset($_POST['service_postID']) ? absint(wp_unslash($_POST['service_postID'])) : 0;
+				if (!$this->ensure_post_edit_permission($post_id)) {
+					return;
+				}
 				$services = $this->get_services($post_id);
 				if (!empty($services)) {
 					if (isset($_POST['itemId'])) {

--- a/Frontend/MPWPB_Ajax_File_Upload.php
+++ b/Frontend/MPWPB_Ajax_File_Upload.php
@@ -46,7 +46,8 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
          */
         public function handle_file_upload() {
             // Check nonce
-            if (!isset($_POST['nonce']) || !wp_verify_nonce($_POST['nonce'], 'mpwpb_file_upload_nonce')) {
+            $nonce = isset($_POST['nonce']) ? sanitize_text_field(wp_unslash($_POST['nonce'])) : '';
+            if (!$nonce || !wp_verify_nonce($nonce, 'mpwpb_file_upload_nonce')) {
                 wp_send_json_error(array('message' => 'Invalid nonce'));
                 return;
             }
@@ -66,6 +67,22 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
                 wp_send_json_error(array('message' => 'File has zero size'));
                 return;
             }
+            $max_upload_size = apply_filters('mpwpb_max_checkout_upload_size', 5 * MB_IN_BYTES);
+            if ($_FILES['file']['size'] > $max_upload_size) {
+                wp_send_json_error(array('message' => 'File is too large'));
+                return;
+            }
+            $filename = isset($_FILES['file']['name']) ? sanitize_file_name(wp_unslash($_FILES['file']['name'])) : '';
+            $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+            if (!$filename || !in_array($extension, $this->allowed_extensions, true)) {
+                wp_send_json_error(array('message' => 'Invalid file type'));
+                return;
+            }
+            $file_type = wp_check_filetype_and_ext($_FILES['file']['tmp_name'], $filename, $this->allowed_mime_types);
+            if (empty($file_type['ext']) || empty($file_type['type'])) {
+                wp_send_json_error(array('message' => 'Invalid file content'));
+                return;
+            }
             
             // Create upload overrides
             $upload_overrides = array(
@@ -81,11 +98,11 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
                 // error_log('File uploaded successfully via AJAX: ' . $image_url);
                 
                 // Store the file in the media library for better management
-                $filename = basename($movefile['file']);
-                $wp_filetype = wp_check_filetype($filename, null);
+                $saved_filename = basename($movefile['file']);
+                $wp_filetype = wp_check_filetype($saved_filename, null);
                 $attachment = array(
                     'post_mime_type' => $wp_filetype['type'],
-                    'post_title' => sanitize_file_name($filename),
+                    'post_title' => sanitize_file_name($saved_filename),
                     'post_content' => '',
                     'post_status' => 'inherit'
                 );
@@ -101,8 +118,8 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
                 // Return success response
                 wp_send_json_success(array(
                     'url' => $image_url,
-                    'filename' => $_FILES['file']['name'],
-                    'field_name' => isset($_POST['field_name']) ? sanitize_text_field($_POST['field_name']) : '',
+                    'filename' => $filename,
+                    'field_name' => isset($_POST['field_name']) ? sanitize_text_field(wp_unslash($_POST['field_name'])) : '',
                 ));
             } else {
                 $error = isset($movefile['error']) ? $movefile['error'] : 'Unknown error';

--- a/assets/frontend/mpwpb_user_dashboard.js
+++ b/assets/frontend/mpwpb_user_dashboard.js
@@ -298,6 +298,7 @@ jQuery(document).ready(function($) {
             schedule: schedule,
             offDays: offDays,
             offDates_str: offDates_str,
+            nonce: (typeof mpwpb_dashboard !== 'undefined' && mpwpb_dashboard.nonce) ? mpwpb_dashboard.nonce : '',
         }, function(response) {
             if (response.success) {
                 alert('Schedule saved successfully!');

--- a/inc/MPWPB_Function.php
+++ b/inc/MPWPB_Function.php
@@ -11,9 +11,26 @@
 			public function __construct() {}
 			//************************************************************Partially custom Function******************************//
 			//***********Template********************//
+			public static function sanitize_details_template_name($template_name): string {
+				$allowed_templates = array('default.php', 'static.php');
+				$template_name = sanitize_file_name((string)$template_name);
+				$template_name = basename($template_name);
+				if (!in_array($template_name, $allowed_templates, true)) {
+					return 'default.php';
+				}
+				return $template_name;
+			}
+			private static function normalize_template_relative_path($file_name): string {
+				$file_name = wp_normalize_path(ltrim((string)$file_name, '/\\'));
+				if ($file_name === '' || strpos($file_name, '..') !== false) {
+					return '';
+				}
+				return preg_replace('#/+#', '/', $file_name);
+			}
 			public static function details_template_path($post_id = ''): string {
 				$post_id = $post_id ?? get_the_id();
 				$template_name = MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_template', 'default.php');
+				$template_name = self::sanitize_details_template_name($template_name);
 				$file_name = 'themes/' . $template_name;
 				$dir = MPWPB_PLUGIN_DIR . '/templates/' . $file_name;
 				if (!file_exists($dir)) {
@@ -22,11 +39,36 @@
 				return self::template_path($file_name);
 			}
 			public static function template_path($file_name): string {
-				$template_path = get_stylesheet_directory() . '/mpwpb_templates/';
-				$default_dir = MPWPB_PLUGIN_DIR . '/templates/';
-				$dir = is_dir($template_path) ? $template_path : $default_dir;
-				$file_path = $dir . $file_name;
-				return locate_template(['mpwpb_templates/' . $file_name]) ? $file_path : $default_dir . $file_name;
+				$default_dir = trailingslashit(MPWPB_PLUGIN_DIR . '/templates');
+				$file_name = self::normalize_template_relative_path($file_name);
+				if (!$file_name) {
+					return $default_dir . 'themes/default.php';
+				}
+				$default_file_path = $default_dir . $file_name;
+				if (!file_exists($default_file_path)) {
+					return $default_dir . 'themes/default.php';
+				}
+				$theme_file = locate_template(array('mpwpb_templates/' . $file_name));
+				if ($theme_file) {
+					$resolved_theme_file = realpath($theme_file);
+					$allowed_theme_dirs = array(
+						realpath(get_stylesheet_directory() . '/mpwpb_templates'),
+						realpath(get_template_directory() . '/mpwpb_templates'),
+					);
+					if ($resolved_theme_file) {
+						$resolved_theme_file = wp_normalize_path($resolved_theme_file);
+						foreach ($allowed_theme_dirs as $allowed_theme_dir) {
+							if (!$allowed_theme_dir) {
+								continue;
+							}
+							$allowed_theme_dir = trailingslashit(wp_normalize_path($allowed_theme_dir));
+							if (strpos($resolved_theme_file, $allowed_theme_dir) === 0) {
+								return $resolved_theme_file;
+							}
+						}
+					}
+				}
+				return $default_file_path;
 			}
 			//************************//
 			public static function get_general_settings($key, $default = '') {


### PR DESCRIPTION
Address a local file inclusion vector and multiple authorization weaknesses in service booking flows.

Security changes:

- Prevent LFI in service detail template loading by centralizing template sanitization and enforcing a strict allowlist (default.php, static.php).

- Block directory traversal and invalid relative paths in template resolution, with safe fallback to default theme template.

- Fix broken nonce/autosave/capability guard logic in save handlers where operator precedence allowed bypass conditions.

- Add explicit capability checks (current_user_can('edit_post', )) across admin AJAX handlers that read/write service, category, extra-service, FAQ, and date/time meta.

- Remove unnecessary wp_ajax_nopriv_* registrations from admin-only endpoints to reduce unauthenticated attack surface.

- Protect admin option mutation endpoint (mpwpb_disable_field) with manage_options authorization.

- Harden staff management AJAX handlers with create_users checks and corrected nonce validation logic.

- Add nonce and role/permission validation to staff specific schedule save endpoint and pass dashboard nonce from frontend JS.

- Replace unsafe unserialize() usage with maybe_unserialize() and enforce array type handling for booking service metadata.

- Harden checkout file upload AJAX handling with sanitized nonce input, max size checks, extension/mime/content validation, and sanitized field inputs.

Impact:

- Contributor-supplied template traversal payloads now resolve to safe templates only.

- Unauthorized or guest-triggered admin metadata mutations are rejected.

- CSRF and privilege-escalation paths in several admin/staff actions are significantly reduced.