### PR TITLE
Fix by Shahnur — Extra service save issue 

### DIFF
--- a/Admin/settings/Extra_service.php
+++ b/Admin/settings/Extra_service.php
@@ -10,6 +10,7 @@
 		class MPWPB_Extra_service_Settings {
 			public function __construct() {
 				add_action('add_mpwpb_settings_tab_content', [$this, 'extra_service_settings'], 10, 1);
+				add_action('mpwpb_settings_save', [$this, 'save_extra_service_settings'], 10, 1);
 				// save extra service
 				add_action('wp_ajax_mpwpb_save_ex_service', [$this, 'save_ex_service']);
 				// mpwpb update extra service
@@ -144,6 +145,13 @@
 					'html' => $html_output,
 				]);
 				die;
+			}
+			// Fixed by Shahnur — 2026-04-27 07:23 AM (Asia/Dhaka)
+			public function save_extra_service_settings($post_id) {
+				$extra_service_active = isset($_POST['mpwpb_extra_service_active']) && sanitize_text_field(wp_unslash($_POST['mpwpb_extra_service_active'])) === 'on'
+					? 'on'
+					: 'off';
+				update_post_meta($post_id, 'mpwpb_extra_service_active', $extra_service_active);
 			}
 			public function save_ex_service() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'mpwpb_admin_nonce')) {


### PR DESCRIPTION
Issue: Extra Service enable option became disabled after saving the service post, even after enabling it and adding extra services.

Root cause: The AJAX add-extra-service action set mpwpb_extra_service_active to on, but the normal service post save flow did not persist that switch, so the saved settings could overwrite the active state as disabled.

Resolution: Hooked the Extra Service settings class into mpwpb_settings_save and saved mpwpb_extra_service_active as on/off from the submitted switch value, keeping the existing AJAX extra-service list handling unchanged.

Validation: Ran php -l on Admin/settings/Extra_service.php; no syntax errors detected. Note: local WAMP PHP reports an unrelated Xdebug extension load warning.