### PR TITLE
fix: remove debug console.log statements and improve settings sanitiz…

### DIFF
--- a/assets/frontend/mpwpb_registration.js
+++ b/assets/frontend/mpwpb_registration.js
@@ -651,7 +651,6 @@ function mpwpb_price_calculation($this) {
                     window.location.href = data;
                 },
                 error: function (response) {
-                    console.log(response);
                 }
             });
         } else {
@@ -751,7 +750,6 @@ function mpwpb_price_calculation($this) {
 
     $(document).ready(function () {
         $('.faq-header').on('click', function () {
-            console.log('test');
             $(this).next('.faq-content').slideToggle();
             $(this).find('i').toggleClass('fa-plus fa-minus');
         });

--- a/assets/frontend/mpwpb_user_dashboard.js
+++ b/assets/frontend/mpwpb_user_dashboard.js
@@ -272,7 +272,6 @@ jQuery(document).ready(function($) {
         let offDays = $('input[name="mpwpb_off_days"]').val();
         let offDates = getAllOffDates();
         let offDates_str = JSON.stringify( offDates );
-        // console.log( offDates_str );
 
         var days = ['default', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday'];
         var schedule = {};
@@ -335,33 +334,38 @@ jQuery(document).ready(function($) {
         return offDates;
     }
 
-    // Example: Get on button click
+    // Get selected off dates on button click
     $('#mpmw_staff_get_dates').on('click', function() {
         const dates = getOffDates();
-        console.log('Selected Dates:', dates);
     });
 
     function load_sortable_datepicker(parent, item) {
         if(parent.find('.mp_item_insert_before').length>0){
             jQuery(item).insertBefore(parent.find('.mp_item_insert_before').first()).promise().done(function () {
-                parent.find('.mp_sortable_area').sortable({
-                    handle: jQuery(this).find('.mpwpb_sortable_button')
-                });
+                if (jQuery.fn.sortable) {
+                    parent.find('.mp_sortable_area').sortable({
+                        handle: '.mpwpb_sortable_button'
+                    });
+                }
                 mpwpb_load_date_picker(parent);
             });
         }else {
             parent.find('.mp_item_insert').first().append(item).promise().done(function () {
-                parent.find('.mp_sortable_area').sortable({
-                    handle: jQuery(this).find('.mpwpb_sortable_button')
-                });
+                if (jQuery.fn.sortable) {
+                    parent.find('.mp_sortable_area').sortable({
+                        handle: '.mpwpb_sortable_button'
+                    });
+                }
                 mpwpb_load_date_picker(parent);
             });
         }
         return true;
     }
-    $(document).find('.mp_sortable_area').sortable({
-        handle: $(this).find('.mpwpb_sortable_button')
-    });
+    if ($.fn.sortable) {
+        $(document).find('.mp_sortable_area').sortable({
+            handle: '.mpwpb_sortable_button'
+        });
+    }
 
     $(document).on('click', '.mpwpb_item_remove', function (e) {
         e.preventDefault();

--- a/mp_global/class/MPWPB_Setting_API.php
+++ b/mp_global/class/MPWPB_Setting_API.php
@@ -315,7 +315,22 @@
 			// 	return $options;
 			// }
 			public function sanitize_options($input) {
-				return is_array($input) ? array_map('sanitize_text_field', $input) : sanitize_text_field($input);
+				if (!is_array($input)) {
+					return sanitize_text_field($input);
+				}
+
+				$output = array();
+				foreach ($input as $key => $value) {
+					$sanitize_callback = $this->get_sanitize_callback($key);
+					if ($sanitize_callback && is_callable($sanitize_callback)) {
+						$output[$key] = call_user_func($sanitize_callback, $value);
+					} elseif (is_array($value)) {
+						$output[$key] = array_map('sanitize_text_field', $value);
+					} else {
+						$output[$key] = sanitize_text_field($value);
+					}
+				}
+				return $output;
 			}
 			function get_sanitize_callback($slug = '') {
 				if (empty($slug)) {


### PR DESCRIPTION
…ation

## Changes Overview

### 1. assets/frontend/mpwpb_registration.js
- Removed leftover debug console.log(response) call inside the AJAX error handler for the registration flow. This log was exposing internal server response objects to the browser console in production environments.
- Removed debug console.log('test') from the FAQ header click handler that was accidentally left in during development of the FAQ accordion toggle feature.

### 2. assets/frontend/mpwpb_user_dashboard.js
- Removed console.log('Selected Dates:', dates) debug statement from the #mpmw_staff_get_dates click handler.
- Updated inline comment from vague '// Example: Get on button click' to descriptive '// Get selected off dates on button click' for clarity.
- Fixed load_sortable_datepicker() function: wrapped both jQuery UI sortable() calls inside if (jQuery.fn.sortable) guards to prevent JavaScript errors when jQuery UI Sortable is not loaded. Previously, calling .sortable() without checking availability would throw 'sortable is not a function' errors on pages that do not load jQuery UI.
- Fixed sortable handle selector: changed from handle: jQuery(this).find(...) (which incorrectly captured the outer scope 'this' instead of each sortable item) to handle: '.mpwpb_sortable_button' (a plain CSS selector string), which is the correct way to specify a drag handle in jQuery UI Sortable.
- Applied the same jQuery.fn.sortable guard and handle string fix to the global document-level sortable initialization at the bottom of the ready block.

### 3. mp_global/class/MPWPB_Setting_API.php
- Refactored sanitize_options() method to replace the flat array_map call with a proper per-field sanitization loop. Previously all array values were indiscriminately passed through sanitize_text_field(), which would silently strip valid data for fields that require different sanitization (e.g. URLs, integers, HTML content, checkboxes).
- New logic: (1) For each key, calls get_sanitize_callback($key) to retrieve the field-specific callback registered via the Settings API. (2) If a valid callable callback exists, applies it using call_user_func(). (3) If the value is a nested array (e.g. repeater fields), falls back to array_map('sanitize_text_field', $value). (4) Otherwise applies sanitize_text_field() as the default fallback.
- This ensures that fields with custom sanitization registered via add_settings_field() / Settings API are correctly sanitized according to their declared type rather than being uniformly stripped as plain text.