### PR TITLE
fix: service unit persistence, front-end descriptions, rich HTML edit……or & Gutenberg metabox

### DIFF
--- a/Admin/MPWPB_Settings.php
+++ b/Admin/MPWPB_Settings.php
@@ -158,8 +158,18 @@
 					$service_rating = isset($_POST['mpwpb_service_review_ratings']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_service_review_ratings'])) : '';
 					$service_rating_scale = isset($_POST['mpwpb_service_rating_scale']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_service_rating_scale'])) : '';
 					$service_rating_text = isset($_POST['mpwpb_service_rating_text']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_service_rating_text'])) : '';
-					$service_overview_content =  isset($_POST['mpwpb_service_overview_content']) ? wp_kses_post(wp_unslash($_POST['mpwpb_service_overview_content'])):'';
-					$service_details_content =  isset($_POST['mpwpb_service_details_content']) ? wp_kses_post(wp_unslash($_POST['mpwpb_service_details_content'])):'';
+					// Mirror WordPress core post_content handling: trusted users (with the
+					// 'unfiltered_html' capability, e.g. administrators/editors) may save raw
+					// markup such as <style> blocks and advanced inline CSS; everyone else is
+					// limited to wp_kses_post(). This fixes rich HTML being stripped on save.
+					$service_overview_content =  isset($_POST['mpwpb_service_overview_content']) ? self::sanitize_rich_content(wp_unslash($_POST['mpwpb_service_overview_content'])):'';
+					$service_details_content =  isset($_POST['mpwpb_service_details_content']) ? self::sanitize_rich_content(wp_unslash($_POST['mpwpb_service_details_content'])):'';
+					if (!empty($service_overview_content) && $service_overview_status === 'off') {
+						$service_overview_status = 'on';
+					}
+					if (!empty($service_details_content) && $service_details_status === 'off') {
+						$service_details_status = 'on';
+					}
                     $service_multiple_category_check = isset($_POST['mpwpb_service_multiple_category_check']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_service_multiple_category_check'])) : 'off';
                     $multiple_service_select = isset($_POST['mpwpb_multiple_service_select']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_multiple_service_select'])) : 'off';
                     update_post_meta($post_id, 'mpwpb_features_status', $service_features_status);
@@ -207,6 +217,22 @@
 				$end_name_break = 'mpwpb_' . $day . '_end_break_time';
 				$end_time_break = isset($_POST[$end_name_break]) ? sanitize_text_field(wp_unslash($_POST[$end_name_break])) : '';
 				update_post_meta($post_id, $end_name_break, $end_time_break);
+			}
+			/**
+			 * Sanitize rich editor content (Service Overview / Service Details).
+			 *
+			 * Trusted users with the 'unfiltered_html' capability may store raw markup
+			 * (e.g. <style> blocks / advanced CSS), mirroring how WordPress core treats
+			 * post_content. All other users are restricted to wp_kses_post().
+			 *
+			 * @param string $content Unslashed content from the editor.
+			 * @return string
+			 */
+			public static function sanitize_rich_content($content) {
+				if (current_user_can('unfiltered_html')) {
+					return $content;
+				}
+				return wp_kses_post($content);
 			}
 			public static function description_array($key) {
 				$des = array(

--- a/Admin/settings/Faq.php
+++ b/Admin/settings/Faq.php
@@ -117,11 +117,12 @@
 								<?php
 									$content = '';
 									$editor_id = 'mpwpb_faq_content';
-									$settings = array(
-										'textarea_name' => 'mpwpb_faq_content',
-										'media_buttons' => true,
-										'textarea_rows' => 10,
-									);
+								$settings = array(
+									'textarea_name' => 'mpwpb_faq_content',
+									'wpautop'       => false,
+									'media_buttons' => true,
+									'textarea_rows' => 10,
+								);
 									wp_editor($content, $editor_id, $settings);
 								?>
                                 <div class="mT"></div>

--- a/Admin/settings/Service.php
+++ b/Admin/settings/Service.php
@@ -93,6 +93,7 @@
 				$new_data = [
 					'name' => isset($_POST['service_name'])?sanitize_text_field(wp_unslash($_POST['service_name'])):'',
 					'price' =>isset($_POST['service_price'])? sanitize_text_field(wp_unslash($_POST['service_price'])):'',
+					'service_unit' =>isset($_POST['service_unit'])? sanitize_text_field(wp_unslash($_POST['service_unit'])):'',
 					'duration' => isset($_POST['service_duration'])?sanitize_text_field(wp_unslash($_POST['service_duration'])):'',
 					'details' => isset($_POST['service_description'])?sanitize_text_field(wp_unslash($_POST['service_description'])):'',
 					'icon' => $iconClass,
@@ -426,6 +427,7 @@
 				$new_data = [
 					'name' => isset($_POST['service_name'])?sanitize_text_field(wp_unslash($_POST['service_name'])):'',
 					'price' =>isset($_POST['service_price'])? sanitize_text_field(wp_unslash($_POST['service_price'])):'',
+					'service_unit' =>isset($_POST['service_unit'])? sanitize_text_field(wp_unslash($_POST['service_unit'])):'',
 					'duration' => isset($_POST['service_duration'])?sanitize_text_field(wp_unslash($_POST['service_duration'])):'',
 					'details' => isset($_POST['service_description'])?sanitize_text_field(wp_unslash($_POST['service_description'])):'',
 					'icon' => $iconClass,
@@ -592,6 +594,7 @@
                         data-cat-status="<?php echo esc_attr($service['show_cat_status']); ?>"
                         data-parent-cat="<?php echo esc_attr($service['parent_cat']); ?>"
                         data-sub-cat="<?php echo esc_attr($service['sub_cat']); ?>"
+                        data-service-unit="<?php echo esc_attr(isset($service['service_unit']) ? $service['service_unit'] : ''); ?>"
                         title="<?php echo esc_attr($service['details']); ?>"
                 >
                     <td data-imageid="<?php echo esc_attr($service['image']); ?>">
@@ -631,6 +634,7 @@
                      data-cat-status="<?php echo esc_attr($service['show_cat_status']); ?>"
                      data-parent-cat="<?php echo esc_attr($service['parent_cat']); ?>"
                      data-sub-cat="<?php echo esc_attr($service['sub_cat']); ?>"
+                     data-service-unit="<?php echo esc_attr(isset($service['service_unit']) ? $service['service_unit'] : ''); ?>"
                      title="<?php echo esc_attr($service['details']); ?>"
                 >
                     <div class="mpwpb_service_icon" data-imageid="<?php echo esc_attr($service['image']); ?>">

--- a/Admin/settings/Service_Details.php
+++ b/Admin/settings/Service_Details.php
@@ -145,10 +145,16 @@
 				<?php
 			}
 			public function show_editor($content, $field_name) {
-				$content = $content; // You can set default content if needed.
-				$editor_id = $field_name; // ID for the editor (used internally by wp_editor).
-				$settings = array();
-				wp_editor($content, $editor_id, $settings);
+				$settings = array(
+					'wpautop'          => false,
+					'media_buttons'    => true,
+					'textarea_name'    => $field_name,
+					'textarea_rows'    => 15,
+					'tinymce'          => array(
+						'toolbar1' => 'formatselect,bold,italic,underline,bullist,numlist,link,unlink,forecolor,removeformat',
+					),
+				);
+				wp_editor($content, $field_name, $settings);
 			}
 		}
 		new MPWPB_Service_Details();

--- a/Frontend/MPWPB_Static_Template.php
+++ b/Frontend/MPWPB_Static_Template.php
@@ -150,7 +150,12 @@
 					?>
                     <section id="service-overview">
                         <h2><?php esc_html_e('Service Overview', 'service-booking-manager'); ?></h2>
-						<?php echo wp_kses_post($service_overview_content); ?>
+						<?php
+							// Content is sanitized on save according to the author's capability
+							// (see MPWPB_Settings::sanitize_rich_content), mirroring core post_content.
+							// Re-running wp_kses_post() here would strip admin-authored <style>/CSS.
+							echo do_shortcode($service_overview_content); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
                     </section>
 				<?php
 				endif;
@@ -192,7 +197,12 @@
 					?>
                     <section id="service-details">
                         <h2><?php esc_html_e('Service Details', 'service-booking-manager'); ?></h2>
-						<?php echo wp_kses_post($service_details_content); ?>
+						<?php
+							// Content is sanitized on save according to the author's capability
+							// (see MPWPB_Settings::sanitize_rich_content), mirroring core post_content.
+							// Re-running wp_kses_post() here would strip admin-authored <style>/CSS.
+							echo do_shortcode($service_details_content); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
                     </section>
 				<?php
 				endif;

--- a/assets/admin/mpwpb_admin.js
+++ b/assets/admin/mpwpb_admin.js
@@ -457,6 +457,7 @@
         $('input[name="service_price"]').val('');
         $('input[name="service_price"]').removeClass('required');
 
+        $('input[name="service_unit"]').val('');
         $('input[name="service_duration"]').val('');
         $('textarea[name="service_description"]').val('');
         $('textarea[name="service_image_icon"]').val('');
@@ -556,6 +557,8 @@
         var name = parent.find('td .service-name').text().trim();
         var price = parent.find('td:nth-child(3)').text().trim();
         var duratoin = parent.find('td:nth-child(4)').text().trim();
+        var serviceUnit = parent.data('service-unit');
+        $('input[name="service_unit"]').val(serviceUnit === undefined ? '' : serviceUnit);
         $('.mpwpb_icon_item').hide();
         $('.mpwpb_image_item').hide();
         $('input[name="service_item_id"]').val(itemId);
@@ -608,6 +611,8 @@
         var name = parent.find('.service-name').text().trim();
         var price = parent.find('.mpwpb_service_price').text().trim();
         var duratoin = parent.find('.mpwpb_service_duration').text().trim();
+        var serviceUnit = parent.data('service-unit');
+        $('input[name="service_unit"]').val(serviceUnit === undefined ? '' : serviceUnit);
         $('.mpwpb_icon_item').hide();
         $('.mpwpb_image_item').hide();
         $('input[name="service_item_id"]').val(itemId);
@@ -654,6 +659,7 @@
         var service_image_icon = $('input[name="service_image_icon"]');
         var service_name = $('input[name="service_name"]');
         var service_price = $('input[name="service_price"]');
+        var service_unit = $('input[name="service_unit"]');
         var service_duration = $('input[name="service_duration"]');
         var service_description = $('textarea[name="service_description"]');
         var show_category_status = $('input[name="mpwpb_show_category_status"]');
@@ -668,6 +674,7 @@
                     service_image_icon: service_image_icon.val(),
                     service_name: service_name.val(),
                     service_price: service_price.val(),
+                    service_unit: service_unit.val(),
                     service_duration: service_duration.val(),
                     service_description: service_description.val(),
                     service_postID: postID.val(),

--- a/mp_global/assets/mp_style/mpwpb_plugin_global.js
+++ b/mp_global/assets/mp_style/mpwpb_plugin_global.js
@@ -642,14 +642,20 @@ function mpwpb_sticky_management() {
         let targetTab = target.children('[data-tabs-target-next]:nth-child(' + num_of_tab + ')').data('tabs-target-next');
         active_next_tab(parent, targetTab);
     });
-    $(document).ready(function () {
+    function mpwpb_activate_default_tabs() {
         $('.mpwpb_style .mpwpb_tabs').each(function () {
             let tabLists = $(this).find('.tabLists:first');
             // let tabLists = $(this).find('.mpwpb_add_update_tab:first');
-            let activeTab = tabLists.find('[data-tabs-target].active');
-            let targetTab = activeTab.length > 0 ? activeTab : tabLists.find('[data-tabs-target]').first();
-            targetTab.trigger('click');
+            // Skip groups that already have an active tab so this is safe to call
+            // repeatedly and never disturbs the user's current selection.
+            if (tabLists.find('[data-tabs-target].active').length > 0) {
+                return;
+            }
+            tabLists.find('[data-tabs-target]').first().trigger('click');
         });
+    }
+    $(document).ready(function () {
+        mpwpb_activate_default_tabs();
         $('.mpwpb_style .mpwpb_tabs_next').each(function () {
             let parent = $(this);
             if (parent.find('[data-tabs-target-next].active').length < 1) {
@@ -659,6 +665,23 @@ function mpwpb_sticky_management() {
                 active_next_tab(parent, targetTab);
             }
         });
+    });
+    // The block (Gutenberg) editor mounts/relocates classic meta boxes asynchronously
+    // after DOM ready, so the settings panel can render without an active tab and look
+    // empty. Re-activate the default tab once the page has fully loaded, with a short
+    // bounded retry while the block editor finishes building its meta box area. Guarded
+    // to block-editor screens and idempotent, so the classic editor is unaffected.
+    $(window).on('load', function () {
+        mpwpb_activate_default_tabs();
+        if ($('body').hasClass('block-editor-page')) {
+            let retries = 0;
+            let timer = setInterval(function () {
+                mpwpb_activate_default_tabs();
+                if (++retries >= 10) {
+                    clearInterval(timer);
+                }
+            }, 400);
+        }
     });
     $(document).on('click', '.mpwpb_style [data-tabs-target]', function () {
         if (!$(this).hasClass('active')) {

--- a/templates/registration/category_selection.php
+++ b/templates/registration/category_selection.php
@@ -125,9 +125,9 @@
                                             <h6><?php echo esc_html($service_name); ?></h6>
                                         </div>
                                         <div class="_equalChild">
-                                            <?php if (isset($ex_service_info['details'])) { ?>
+                                            <?php if (!empty($service_details)) { ?>
                                                 <div data-collapse-target="<?php echo esc_attr($unique_id); ?>" data-read data-open-text="<?php esc_attr_e('Close Details', 'service-booking-manager'); ?>" data-close-text="<?php esc_attr_e('View Details', 'service-booking-manager'); ?>">
-                                                    <span data-text>&nbsp;</span>
+                                                    <span data-text><?php esc_html_e('View Details', 'service-booking-manager'); ?></span>
                                                 </div>
                                             <?php } ?>
                                             <?php if ($service_duration) { ?>

--- a/templates/registration/service_selection.php
+++ b/templates/registration/service_selection.php
@@ -54,9 +54,9 @@
                                         <h6><?php echo esc_html($service_name); ?></h6>
                                     </div>
                                     <div class="_equalChild">
-										<?php if (isset($ex_service_info['details'])) { ?>
+										<?php if (!empty($service_details)) { ?>
                                             <div data-collapse-target="<?php echo esc_attr($unique_id); ?>" data-read data-open-text="<?php esc_attr_e('Close Details', 'service-booking-manager'); ?>" data-close-text="<?php esc_attr_e('View Details', 'service-booking-manager'); ?>">
-                                                <span data-text>&nbsp;</span>
+                                                <span data-text><?php esc_html_e('View Details', 'service-booking-manager'); ?></span>
                                             </div>
 										<?php } ?>
 										<?php if ($service_duration) { ?>


### PR DESCRIPTION


Resolves four issues reported via support for the WpBookingly / service-booking-manager plugin.

#1 Rich editor stripped HTML (Service Overview / Service Details)
- Root cause: overview/details content was passed through wp_kses_post() on BOTH save and render, stripping <style> blocks and advanced inline CSS, so admin-authored HTML rendered broken or empty on the front end.
- Fix: add MPWPB_Settings::sanitize_rich_content() — users with the 'unfiltered_html' capability (administrators/editors) may store raw markup, everyone else is still limited to wp_kses_post(), mirroring core post_content. The front end now echoes the already-sanitized content via do_shortcode() instead of re-stripping it.
- Editor config: MPWPB_Service_Details::show_editor() and the FAQ editor now use wpautop=false + media buttons + a stable toolbar; overview/details status auto-enables when content is present.
- Files: Admin/MPWPB_Settings.php, Admin/settings/Service_Details.php, Admin/settings/Faq.php, Frontend/MPWPB_Static_Template.php

#2 Service descriptions never showed on the front end
- Root cause: the "View Details" toggle was gated on an undefined variable ($ex_service_info['details']) copied from the extra-services template, so it never rendered and the description stayed display:none. The toggle label also lived in <span data-text> seeded with &nbsp; and was only populated on click, so even once rendered it appeared as an empty box.
- Fix: gate the toggle on the service's own description (!empty($service_details)) and seed the span with the "View Details" label so it shows on load and toggles correctly with the existing JS.
- Files: templates/registration/service_selection.php, templates/registration/category_selection.php

#3 Editing "Service Unit" on one service changed it on all services
- Root cause: service_unit was only handled in save_service(); it was never cleared in the shared modal, never loaded when editing, never sent by the update AJAX, and never saved by update_service()/clone_services(). The stale shared field therefore bled the last-entered value onto every service saved.
- Fix: wire service_unit through the full lifecycle — add it to update_service() and clone_services() $new_data, expose data-service-unit on both rendered cards, clear it in empty_service_form(), populate it in both edit handlers, and send it from the update AJAX.
- Files: Admin/settings/Service.php, assets/admin/mpwpb_admin.js

#4 Plugin settings metabox was empty in the block (Gutenberg) editor
- Root cause: the settings-panel tabs are activated by a one-shot $(document).ready() that clicks the first tab. The block editor mounts and relocates classic meta boxes AFTER ready, so the panel rendered with no active tab and appeared empty.
- Fix: refactor tab activation into an idempotent mpwpb_activate_default_tabs() (skips groups that already have an active tab) and re-run it on window load, with a short bounded retry scoped to body.block-editor-page only. Classic editor behaviour is unchanged.
- File: mp_global/assets/mp_style/mpwpb_plugin_global.js

Security note: #1 intentionally renders overview/details without an output-time wp_kses_post(); this is safe because the content is sanitized at save time by user capability (the same trust model as core post_content) and legacy data was already filtered.