### PR TITLE
Add unified admin help and guide center

### DIFF
--- a/Admin/MPWPB_Admin.php
+++ b/Admin/MPWPB_Admin.php
@@ -18,6 +18,7 @@
 				add_filter('wp_mail_content_type', array($this, 'email_content_type'));
 			}
 			private function load_file(): void {
+				require_once MPWPB_PLUGIN_DIR . '/Admin/MPWPB_Help_Guide.php';
 				require_once MPWPB_PLUGIN_DIR . '/Admin/MPWPB_Taxonomy.php';
 				require_once MPWPB_PLUGIN_DIR . '/Admin/MPWPB_Dummy_Import.php';
 				if (MPWPB_Global_Function::is_wc_payment_mode()) {

--- a/Admin/MPWPB_Help_Guide.php
+++ b/Admin/MPWPB_Help_Guide.php
@@ -1,0 +1,248 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+if (!class_exists('MPWPB_Help_Guide')) {
+	class MPWPB_Help_Guide {
+		private $page_hook = '';
+
+		public function __construct() {
+			add_action('admin_menu', array($this, 'register_menu'), 99);
+			add_action('admin_enqueue_scripts', array($this, 'enqueue_assets'));
+		}
+
+		public function register_menu() {
+			$capability = apply_filters('mpwpb_help_guide_capability', 'manage_options');
+			$this->page_hook = add_submenu_page(
+				'edit.php?post_type=mpwpb_item',
+				esc_html__('WPBookingly Help Center', 'service-booking-manager'),
+				esc_html__('Help & Guide', 'service-booking-manager'),
+				$capability,
+				'mpwpb_help_guide',
+				array($this, 'render_page'),
+				99
+			);
+		}
+
+		public function enqueue_assets($hook) {
+			if (!$this->page_hook || $hook !== $this->page_hook) {
+				return;
+			}
+
+			wp_enqueue_style(
+				'mpwpb-help-guide',
+				MPWPB_PLUGIN_URL . '/assets/admin/mpwpb-help-guide.css',
+				array('dashicons'),
+				'1.0.0'
+			);
+			wp_enqueue_script(
+				'mpwpb-help-guide',
+				MPWPB_PLUGIN_URL . '/assets/admin/mpwpb-help-guide.js',
+				array(),
+				'1.0.0',
+				true
+			);
+			wp_localize_script('mpwpb-help-guide', 'mpwpbHelpGuide', array(
+				'copied'      => esc_html__('Topic link copied.', 'service-booking-manager'),
+				'copyFailed'  => esc_html__('Copy the address from your browser.', 'service-booking-manager'),
+				'proRequired' => esc_html__('This guide topic requires Service Booking Manager Pro to be active.', 'service-booking-manager'),
+			));
+		}
+
+		private function admin_urls() {
+			return array(
+				'services'       => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_list'),
+				'add_service'    => admin_url('post-new.php?post_type=mpwpb_item'),
+				'coupons'        => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_coupon_list'),
+				'staff'          => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_staffs'),
+				'settings'       => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_settings_page'),
+				'status'         => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_status_page'),
+				'reviews'        => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb-reviews'),
+				'analytics'      => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_analytics_dashboard'),
+				'orders'         => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_order_list'),
+				'queue'          => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_queue'),
+				'calendar'       => admin_url('edit.php?post_type=mpwpb_item&page=mp-custom-calendar'),
+				'backend_order'  => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_create_order'),
+				'gdpr_tools'     => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_gdpr_tools'),
+				'audit_logs'     => admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_audit_logs'),
+				'profile'        => admin_url('profile.php'),
+			);
+		}
+
+		private function sections() {
+			require_once MPWPB_PLUGIN_DIR . '/Admin/MPWPB_Help_Guide_Content.php';
+			$sections = MPWPB_Help_Guide_Content::get_sections();
+			$sections = apply_filters('mpwpb_help_guide_sections', $sections, array(
+				'pro_active' => class_exists('MPWPB_Admin_Pro'),
+				'urls'       => $this->admin_urls(),
+			));
+
+			return is_array($sections) ? $sections : array();
+		}
+
+		private function has_pro_content($sections) {
+			foreach ($sections as $section) {
+				if (isset($section['tier']) && 'pro' === $section['tier']) {
+					return true;
+				}
+				foreach (isset($section['topics']) && is_array($section['topics']) ? $section['topics'] : array() as $topic) {
+					if (isset($topic['tier']) && 'pro' === $topic['tier']) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		private function icon($name) {
+			$icons = array(
+				'start' => 'dashicons-lightbulb', 'map' => 'dashicons-location-alt',
+				'service' => 'dashicons-admin-tools', 'calendar' => 'dashicons-calendar-alt',
+				'pricing' => 'dashicons-money-alt', 'staff' => 'dashicons-groups',
+				'booking' => 'dashicons-tickets-alt', 'payment' => 'dashicons-cart',
+				'coupon' => 'dashicons-tag', 'review' => 'dashicons-star-filled',
+				'analytics' => 'dashicons-chart-bar', 'privacy' => 'dashicons-shield',
+				'style' => 'dashicons-art', 'tools' => 'dashicons-sos',
+				'orders' => 'dashicons-clipboard', 'document' => 'dashicons-media-document',
+				'integration' => 'dashicons-admin-links', 'security' => 'dashicons-lock',
+				'license' => 'dashicons-admin-network',
+			);
+			return isset($icons[$name]) ? $icons[$name] : 'dashicons-book-alt';
+		}
+
+		public function render_page() {
+			$capability = apply_filters('mpwpb_help_guide_capability', 'manage_options');
+			if (!current_user_can($capability)) {
+				wp_die(esc_html__('You do not have permission to view this guide.', 'service-booking-manager'));
+			}
+
+			$sections = $this->sections();
+			$has_pro = $this->has_pro_content($sections);
+			$urls = $this->admin_urls();
+			?>
+			<div class="wrap mpwpb-guide" data-has-pro="<?php echo $has_pro ? '1' : '0'; ?>">
+				<div class="mpwpb-guide__hero">
+					<div class="mpwpb-guide__hero-copy">
+						<span class="mpwpb-guide__eyebrow"><?php esc_html_e('Booking management, explained clearly', 'service-booking-manager'); ?></span>
+						<h1><?php esc_html_e('WPBookingly Help Center', 'service-booking-manager'); ?></h1>
+						<p><?php esc_html_e('Find any feature, understand every setting, and follow practical steps to configure your booking system with confidence.', 'service-booking-manager'); ?></p>
+					</div>
+					<div class="mpwpb-guide__edition">
+						<span class="dashicons dashicons-yes-alt" aria-hidden="true"></span>
+						<span><?php echo $has_pro ? esc_html__('Free + Pro guide', 'service-booking-manager') : esc_html__('Free guide', 'service-booking-manager'); ?></span>
+					</div>
+					<div class="mpwpb-guide__search-wrap">
+						<label for="mpwpb-guide-search"><?php esc_html_e('Search the guide', 'service-booking-manager'); ?></label>
+						<span class="dashicons dashicons-search" aria-hidden="true"></span>
+						<input id="mpwpb-guide-search" type="search" placeholder="<?php esc_attr_e('Try “buffer time”, “coupon”, “Stripe”…', 'service-booking-manager'); ?>" autocomplete="off">
+						<kbd>/</kbd>
+					</div>
+				</div>
+
+				<div id="mpwpb-guide-pro-notice" class="mpwpb-guide__notice" hidden></div>
+
+				<div class="mpwpb-guide__quick" aria-label="<?php esc_attr_e('Quick start', 'service-booking-manager'); ?>">
+					<a href="<?php echo esc_url($urls['add_service']); ?>"><strong>1</strong><span><?php esc_html_e('Create a service', 'service-booking-manager'); ?></span></a>
+					<a href="#free-availability"><strong>2</strong><span><?php esc_html_e('Set availability', 'service-booking-manager'); ?></span></a>
+					<a href="#free-payments"><strong>3</strong><span><?php esc_html_e('Choose payments', 'service-booking-manager'); ?></span></a>
+					<a href="#free-staff"><strong>4</strong><span><?php esc_html_e('Assign staff', 'service-booking-manager'); ?></span></a>
+					<a href="#free-first-test"><strong>5</strong><span><?php esc_html_e('Test a booking', 'service-booking-manager'); ?></span></a>
+				</div>
+
+				<div class="mpwpb-guide__toolbar">
+					<div class="mpwpb-guide__mobile-nav">
+						<label for="mpwpb-guide-section-select"><?php esc_html_e('Jump to a section', 'service-booking-manager'); ?></label>
+						<select id="mpwpb-guide-section-select">
+							<option value=""><?php esc_html_e('Choose a section…', 'service-booking-manager'); ?></option>
+							<?php foreach ($sections as $section) : ?>
+								<option value="#<?php echo esc_attr($section['id']); ?>"><?php echo esc_html($section['title']); ?></option>
+							<?php endforeach; ?>
+						</select>
+					</div>
+					<div class="mpwpb-guide__filters" aria-label="<?php esc_attr_e('Filter guide', 'service-booking-manager'); ?>">
+						<button type="button" class="is-active" data-tier="all" aria-pressed="true"><?php esc_html_e('All', 'service-booking-manager'); ?></button>
+						<button type="button" data-tier="free" aria-pressed="false"><?php esc_html_e('Free', 'service-booking-manager'); ?></button>
+						<?php if ($has_pro) : ?><button type="button" data-tier="pro" aria-pressed="false"><?php esc_html_e('Pro', 'service-booking-manager'); ?></button><?php endif; ?>
+					</div>
+					<button type="button" class="mpwpb-guide__expand" data-expanded="false"><?php esc_html_e('Expand all', 'service-booking-manager'); ?></button>
+					<span id="mpwpb-guide-results" class="mpwpb-guide__results" aria-live="polite"></span>
+				</div>
+
+				<div class="mpwpb-guide__layout">
+					<nav class="mpwpb-guide__nav" aria-label="<?php esc_attr_e('Guide sections', 'service-booking-manager'); ?>">
+						<p><?php esc_html_e('Guide contents', 'service-booking-manager'); ?></p>
+						<?php foreach ($sections as $section) : ?>
+							<a href="#<?php echo esc_attr($section['id']); ?>" data-tier="<?php echo esc_attr($section['tier']); ?>">
+								<span class="dashicons <?php echo esc_attr($this->icon($section['icon'])); ?>" aria-hidden="true"></span>
+								<span><?php echo esc_html($section['title']); ?></span>
+								<small><?php echo 'pro' === $section['tier'] ? esc_html__('PRO', 'service-booking-manager') : esc_html__('FREE', 'service-booking-manager'); ?></small>
+							</a>
+						<?php endforeach; ?>
+					</nav>
+
+					<main class="mpwpb-guide__content">
+						<?php foreach ($sections as $section) : $this->render_section($section, $urls); endforeach; ?>
+						<div class="mpwpb-guide__empty" hidden>
+							<span class="dashicons dashicons-search" aria-hidden="true"></span>
+							<h2><?php esc_html_e('No guide topics found', 'service-booking-manager'); ?></h2>
+							<p><?php esc_html_e('Try a simpler term such as service, schedule, payment, staff, coupon, or email.', 'service-booking-manager'); ?></p>
+							<button type="button"><?php esc_html_e('Clear search', 'service-booking-manager'); ?></button>
+						</div>
+					</main>
+				</div>
+				<div id="mpwpb-guide-live" class="screen-reader-text" aria-live="polite"></div>
+			</div>
+			<?php
+		}
+
+		private function render_section($section, $urls) {
+			$topics = isset($section['topics']) && is_array($section['topics']) ? $section['topics'] : array();
+			?>
+			<section id="<?php echo esc_attr($section['id']); ?>" class="mpwpb-guide__section" data-tier="<?php echo esc_attr($section['tier']); ?>">
+				<header class="mpwpb-guide__section-head">
+					<div class="mpwpb-guide__section-icon"><span class="dashicons <?php echo esc_attr($this->icon($section['icon'])); ?>" aria-hidden="true"></span></div>
+					<div><span class="mpwpb-guide__tier mpwpb-guide__tier--<?php echo esc_attr($section['tier']); ?>"><?php echo 'pro' === $section['tier'] ? esc_html__('Pro', 'service-booking-manager') : esc_html__('Free', 'service-booking-manager'); ?></span><h2><?php echo esc_html($section['title']); ?></h2><p><?php echo esc_html($section['description']); ?></p></div>
+				</header>
+				<div class="mpwpb-guide__topics">
+					<?php foreach ($topics as $topic) : $this->render_topic($topic, $urls); endforeach; ?>
+				</div>
+			</section>
+			<?php
+		}
+
+		private function render_topic($topic, $urls) {
+			$fields = isset($topic['fields']) && is_array($topic['fields']) ? $topic['fields'] : array();
+			$steps = isset($topic['steps']) && is_array($topic['steps']) ? $topic['steps'] : array();
+			$tier = isset($topic['tier']) ? $topic['tier'] : 'free';
+			$search = implode(' ', array($topic['title'], $topic['summary'], $topic['where'], isset($topic['keywords']) ? $topic['keywords'] : ''));
+			foreach ($fields as $field) {
+				$search .= ' ' . $field['label'] . ' ' . $field['description'] . ' ' . (isset($field['tip']) ? $field['tip'] : '');
+			}
+			?>
+			<article id="<?php echo esc_attr($topic['id']); ?>" class="mpwpb-guide__topic" data-tier="<?php echo esc_attr($tier); ?>" data-search="<?php echo esc_attr(wp_strip_all_tags($search)); ?>">
+				<button type="button" class="mpwpb-guide__topic-toggle" aria-expanded="false" aria-controls="<?php echo esc_attr($topic['id']); ?>-body">
+					<span><span class="mpwpb-guide__tier mpwpb-guide__tier--<?php echo esc_attr($tier); ?>"><?php echo 'pro' === $tier ? esc_html__('Pro', 'service-booking-manager') : esc_html__('Free', 'service-booking-manager'); ?></span><strong><?php echo esc_html($topic['title']); ?></strong><small><?php echo esc_html($topic['summary']); ?></small></span>
+					<span class="dashicons dashicons-arrow-down-alt2" aria-hidden="true"></span>
+				</button>
+				<div id="<?php echo esc_attr($topic['id']); ?>-body" class="mpwpb-guide__topic-body">
+					<div class="mpwpb-guide__where"><span class="dashicons dashicons-location" aria-hidden="true"></span><div><strong><?php esc_html_e('Where to find it', 'service-booking-manager'); ?></strong><span><?php echo esc_html($topic['where']); ?></span></div></div>
+					<?php if (!empty($topic['note'])) : ?><div class="mpwpb-guide__callout"><span class="dashicons dashicons-info-outline" aria-hidden="true"></span><p><?php echo esc_html($topic['note']); ?></p></div><?php endif; ?>
+					<?php if ($steps) : ?><ol class="mpwpb-guide__steps"><?php foreach ($steps as $step) : ?><li><?php echo esc_html($step); ?></li><?php endforeach; ?></ol><?php endif; ?>
+					<?php if ($fields) : ?>
+						<div class="mpwpb-guide__fields">
+							<h3><?php esc_html_e('Settings explained', 'service-booking-manager'); ?></h3>
+							<dl><?php foreach ($fields as $field) : ?><div><dt><?php echo esc_html($field['label']); ?></dt><dd><?php echo esc_html($field['description']); ?><?php if (!empty($field['tip'])) : ?><small><?php echo esc_html($field['tip']); ?></small><?php endif; ?></dd></div><?php endforeach; ?></dl>
+						</div>
+					<?php endif; ?>
+					<div class="mpwpb-guide__actions">
+						<?php if (!empty($topic['url_key']) && isset($urls[$topic['url_key']])) : ?><a class="mpwpb-guide__open" href="<?php echo esc_url($urls[$topic['url_key']]); ?>"><?php esc_html_e('Open this area', 'service-booking-manager'); ?><span class="dashicons dashicons-arrow-right-alt" aria-hidden="true"></span></a><?php endif; ?>
+						<button type="button" class="mpwpb-guide__copy" data-topic="<?php echo esc_attr($topic['id']); ?>"><span class="dashicons dashicons-admin-links" aria-hidden="true"></span><?php esc_html_e('Copy topic link', 'service-booking-manager'); ?></button>
+					</div>
+				</div>
+			</article>
+			<?php
+		}
+	}
+	new MPWPB_Help_Guide();
+}

--- a/Admin/MPWPB_Help_Guide_Content.php
+++ b/Admin/MPWPB_Help_Guide_Content.php
@@ -1,0 +1,257 @@
+<?php
+if (!defined('ABSPATH')) {
+	exit;
+}
+
+if (!class_exists('MPWPB_Help_Guide_Content')) {
+	class MPWPB_Help_Guide_Content {
+		private static function field($label, $description, $tip = '') {
+			return array('label' => $label, 'description' => $description, 'tip' => $tip);
+		}
+
+		private static function topic($id, $title, $summary, $where, $fields = array(), $options = array()) {
+			return array_merge(array(
+				'id' => $id, 'title' => $title, 'summary' => $summary, 'where' => $where,
+				'tier' => 'free', 'fields' => $fields, 'steps' => array(), 'note' => '',
+				'keywords' => '', 'url_key' => '',
+			), $options);
+		}
+
+		private static function section($id, $title, $description, $icon, $topics) {
+			return array('id' => $id, 'title' => $title, 'description' => $description, 'icon' => $icon, 'tier' => 'free', 'topics' => $topics);
+		}
+
+		public static function get_sections() {
+			return array(
+				self::section('free-start', __('Start Here', 'service-booking-manager'), __('A practical path from installation to a successful test booking.', 'service-booking-manager'), 'start', array(
+					self::topic('free-launch-checklist', __('Five-step launch checklist', 'service-booking-manager'), __('Complete the essential setup in the right order.', 'service-booking-manager'), __('WPBookingly menu', 'service-booking-manager'), array(), array(
+						'steps' => array(
+							__('Create a service and give it a clear public title.', 'service-booking-manager'),
+							__('Add services, prices, duration, capacity, and optional extras.', 'service-booking-manager'),
+							__('Set bookable dates, working hours, breaks, and unavailable dates.', 'service-booking-manager'),
+							__('Choose WooCommerce or the available checkout mode and confirm its settings.', 'service-booking-manager'),
+							__('Publish the service, open it as a customer, and complete a real test booking.', 'service-booking-manager'),
+						),
+						'url_key' => 'add_service', 'keywords' => 'setup wizard configure launch getting started',
+					)),
+					self::topic('free-first-test', __('Run your first test booking', 'service-booking-manager'), __('Test the full customer journey before sharing a service.', 'service-booking-manager'), __('WPBookingly → Service List → View a published service', 'service-booking-manager'), array(), array(
+						'steps' => array(
+							__('Use a future date that has available working hours.', 'service-booking-manager'),
+							__('Select a service, staff member if enabled, and any extras.', 'service-booking-manager'),
+							__('Complete checkout with a test-safe payment method.', 'service-booking-manager'),
+							__('Confirm the booking appears in the appropriate order or booking view and that emails arrive.', 'service-booking-manager'),
+						),
+						'note' => __('Use a separate customer email address so you can check exactly what a real customer receives.', 'service-booking-manager'),
+						'url_key' => 'services', 'keywords' => 'test booking publish preview customer journey email',
+					)),
+				)),
+
+				self::section('free-admin-map', __('Admin Map', 'service-booking-manager'), __('Know which screen to open for each everyday task.', 'service-booking-manager'), 'map', array(
+					self::topic('free-admin-pages', __('Where everything lives', 'service-booking-manager'), __('A quick map of the WPBookingly administration area.', 'service-booking-manager'), __('WordPress Admin → WPBookingly', 'service-booking-manager'), array(
+						self::field(__('Service List', 'service-booking-manager'), __('Create, edit, duplicate, publish, and preview bookable services.', 'service-booking-manager')),
+						self::field(__('Coupons', 'service-booking-manager'), __('Create promotional codes and control when, where, and how often each code works.', 'service-booking-manager')),
+						self::field(__('Status', 'service-booking-manager'), __('Check server, WordPress, WooCommerce, and supporting-component health.', 'service-booking-manager')),
+						self::field(__('Reviews', 'service-booking-manager'), __('Review customer feedback and moderate its visibility.', 'service-booking-manager')),
+						self::field(__('Staff Members', 'service-booking-manager'), __('Create staff profiles, assign services, and manage personal working schedules.', 'service-booking-manager')),
+						self::field(__('Settings', 'service-booking-manager'), __('Control global labels, URLs, checkout, privacy, display, timing, and appearance.', 'service-booking-manager')),
+						self::field(__('Analytics', 'service-booking-manager'), __('Measure bookings and revenue, filter results, and export CSV data.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'menu navigation find screen admin')),
+				)),
+
+				self::section('free-service', __('Creating a Service', 'service-booking-manager'), __('Build the information, choices, pricing, and presentation customers see.', 'service-booking-manager'), 'service', array(
+					self::topic('free-service-general', __('General information and display', 'service-booking-manager'), __('Name the service and control its public presentation.', 'service-booking-manager'), __('WPBookingly → Service List → Add New or Edit → General', 'service-booking-manager'), array(
+						self::field(__('Service title', 'service-booking-manager'), __('The main public name shown in WordPress and the booking page.', 'service-booking-manager'), __('Use a specific customer-friendly name such as “60-minute Consultation”.', 'service-booking-manager')),
+						self::field(__('Shortcode title', 'service-booking-manager'), __('Optional heading displayed above the embedded booking interface.', 'service-booking-manager')),
+						self::field(__('Shortcode subtitle', 'service-booking-manager'), __('Supporting sentence shown with the booking interface.', 'service-booking-manager')),
+						self::field(__('Template', 'service-booking-manager'), __('Chooses the available frontend layout for this service.', 'service-booking-manager')),
+						self::field(__('Featured image / thumbnail', 'service-booking-manager'), __('The primary visual used in service cards and the service page.', 'service-booking-manager')),
+						self::field(__('Service overview', 'service-booking-manager'), __('Controls and supplies the longer introduction customers read before booking.', 'service-booking-manager')),
+					), array('url_key' => 'add_service', 'keywords' => 'title subtitle thumbnail template overview shortcode')),
+					self::topic('free-categories-services', __('Categories and service choices', 'service-booking-manager'), __('Organize related choices and define each billable service.', 'service-booking-manager'), __('Edit Service → Categories & Services', 'service-booking-manager'), array(
+						self::field(__('Enable multiple categories', 'service-booking-manager'), __('Allows the booking form to present more than one category group.', 'service-booking-manager')),
+						self::field(__('Enable multiple service selection', 'service-booking-manager'), __('Lets a customer choose more than one service in the same booking where supported.', 'service-booking-manager')),
+						self::field(__('Category', 'service-booking-manager'), __('A top-level group such as Cleaning, Beauty, or Consultation.', 'service-booking-manager')),
+						self::field(__('Subcategory', 'service-booking-manager'), __('An optional second level used to keep a large catalog easy to scan.', 'service-booking-manager')),
+						self::field(__('Service name', 'service-booking-manager'), __('The choice the customer selects inside a category.', 'service-booking-manager')),
+						self::field(__('Price', 'service-booking-manager'), __('Base cost for one unit of this service.', 'service-booking-manager')),
+						self::field(__('Unit', 'service-booking-manager'), __('Explains what the price covers, such as person, room, hour, or item.', 'service-booking-manager')),
+						self::field(__('Duration', 'service-booking-manager'), __('Customer-facing duration text for this choice.', 'service-booking-manager')),
+						self::field(__('Description', 'service-booking-manager'), __('Short details that help the customer choose correctly.', 'service-booking-manager')),
+						self::field(__('Image or icon', 'service-booking-manager'), __('Visual identifier shown with the choice.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'category subcategory service price unit duration quantity multiple')),
+					self::topic('free-extra-services', __('Extra services', 'service-booking-manager'), __('Offer optional add-ons alongside the main booking.', 'service-booking-manager'), __('Edit Service → Extra Services', 'service-booking-manager'), array(
+						self::field(__('Extra service name', 'service-booking-manager'), __('The add-on label customers see, such as “Deep conditioning”.', 'service-booking-manager')),
+						self::field(__('Extra price', 'service-booking-manager'), __('Additional amount charged for each selected extra.', 'service-booking-manager')),
+						self::field(__('Available quantity', 'service-booking-manager'), __('Maximum quantity a customer may choose.', 'service-booking-manager')),
+						self::field(__('Description', 'service-booking-manager'), __('Clarifies what the extra includes.', 'service-booking-manager')),
+						self::field(__('Image or icon', 'service-booking-manager'), __('Makes the optional add-on easier to identify.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'addon add-on extras upsell quantity')),
+					self::topic('free-service-content', __('Details, features, FAQ, ratings, and gallery', 'service-booking-manager'), __('Add the information customers need before making a decision.', 'service-booking-manager'), __('Edit Service → Service Features / Details / FAQ / Gallery', 'service-booking-manager'), array(
+						self::field(__('Feature or detail rows', 'service-booking-manager'), __('Structured highlights such as inclusions, facilities, or benefits.', 'service-booking-manager')),
+						self::field(__('Displayed rating', 'service-booking-manager'), __('Optional rating value presented in the service information.', 'service-booking-manager')),
+						self::field(__('Rating scale', 'service-booking-manager'), __('Explains the maximum score, for example “Out of 5”.', 'service-booking-manager')),
+						self::field(__('Rating text', 'service-booking-manager'), __('Supporting text such as the number of ratings.', 'service-booking-manager')),
+						self::field(__('FAQ question and answer', 'service-booking-manager'), __('Reusable customer guidance shown as common questions.', 'service-booking-manager')),
+						self::field(__('Gallery images', 'service-booking-manager'), __('Additional photos that explain the location, result, or experience.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'details feature faq question answer rating gallery images')),
+				)),
+
+				self::section('free-availability', __('Availability & Scheduling', 'service-booking-manager'), __('Control which dates and times customers can actually reserve.', 'service-booking-manager'), 'calendar', array(
+					self::topic('free-service-schedule', __('Service dates, hours, slots, and capacity', 'service-booking-manager'), __('Build the service’s bookable calendar and prevent invalid slots.', 'service-booking-manager'), __('Edit Service → Date & Time', 'service-booking-manager'), array(
+						self::field(__('Date type', 'service-booking-manager'), __('Choose a repeating schedule or a list of particular dates.', 'service-booking-manager')),
+						self::field(__('Repeated start date', 'service-booking-manager'), __('First day from which the repeating schedule can be booked.', 'service-booking-manager')),
+						self::field(__('Repeat for / repeated after', 'service-booking-manager'), __('Defines the repeating schedule window.', 'service-booking-manager')),
+						self::field(__('Active days', 'service-booking-manager'), __('Limits how far or how many days the repeating availability remains active.', 'service-booking-manager')),
+						self::field(__('Time-slot length', 'service-booking-manager'), __('Splits working hours into selectable appointment intervals.', 'service-booking-manager'), __('Match this to the real time needed for one appointment.', 'service-booking-manager')),
+						self::field(__('Capacity per session', 'service-booking-manager'), __('Maximum bookings accepted for the same slot.', 'service-booking-manager')),
+						self::field(__('Particular dates', 'service-booking-manager'), __('Explicit dates used when availability is not weekly or repeating.', 'service-booking-manager')),
+						self::field(__('Off days / off dates', 'service-booking-manager'), __('Dates that must remain unavailable even if normal hours would allow booking.', 'service-booking-manager')),
+						self::field(__('Weekday start and end time', 'service-booking-manager'), __('Opening and closing time for each active weekday.', 'service-booking-manager')),
+						self::field(__('Break start and end time', 'service-booking-manager'), __('Removes a daily interval such as lunch from bookable time.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'date time availability capacity slot repeat particular hours break off holiday')),
+					self::topic('free-global-timing', __('Global booking timing rules', 'service-booking-manager'), __('Add preparation time and control how late customers may change bookings.', 'service-booking-manager'), __('WPBookingly → Settings → General', 'service-booking-manager'), array(
+						self::field(__('Buffer time', 'service-booking-manager'), __('Adds protected time around appointments so bookings are not placed too close together.', 'service-booking-manager')),
+						self::field(__('Cancellation lead time', 'service-booking-manager'), __('Minimum notice required before a customer can cancel.', 'service-booking-manager')),
+						self::field(__('Reschedule lead time', 'service-booking-manager'), __('Minimum notice required before a customer can move a booking.', 'service-booking-manager')),
+						self::field(__('Booked order statuses', 'service-booking-manager'), __('WooCommerce statuses counted as reserving capacity.', 'service-booking-manager'), __('Include only statuses that truly represent a confirmed or held booking.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'buffer lead cancellation reschedule booked status')),
+				)),
+
+				self::section('free-pricing', __('Pricing, Tax & Discounts', 'service-booking-manager'), __('Explain the total clearly and control tax and repeating-booking incentives.', 'service-booking-manager'), 'pricing', array(
+					self::topic('free-tax', __('Tax settings', 'service-booking-manager'), __('Apply a percentage tax to a service when required.', 'service-booking-manager'), __('Edit Service → Tax Settings', 'service-booking-manager'), array(
+						self::field(__('Enable tax', 'service-booking-manager'), __('Turns tax calculation on for this service.', 'service-booking-manager')),
+						self::field(__('Tax class', 'service-booking-manager'), __('Associates the service with the available tax category.', 'service-booking-manager')),
+						self::field(__('Tax rate', 'service-booking-manager'), __('Percentage added according to the configured calculation.', 'service-booking-manager'), __('Confirm local tax requirements with a qualified adviser.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'tax vat percentage rate class')),
+					self::topic('free-recurring', __('Recurring bookings', 'service-booking-manager'), __('Allow a customer to reserve a repeated series instead of one appointment.', 'service-booking-manager'), __('Edit Service → Recurring Booking', 'service-booking-manager'), array(
+						self::field(__('Recurring types', 'service-booking-manager'), __('Permitted patterns: daily, weekly, bi-weekly, or monthly.', 'service-booking-manager')),
+						self::field(__('Maximum recurring count', 'service-booking-manager'), __('Largest number of occurrences a customer may book at once.', 'service-booking-manager')),
+						self::field(__('Recurring discount', 'service-booking-manager'), __('Percentage incentive applied to a repeating series.', 'service-booking-manager')),
+					), array('url_key' => 'services', 'keywords' => 'recurring repeat daily weekly biweekly monthly discount')),
+				)),
+
+				self::section('free-staff', __('Staff', 'service-booking-manager'), __('Create team members, assign work, and give each person a realistic schedule.', 'service-booking-manager'), 'staff', array(
+					self::topic('free-staff-management', __('Staff profiles and service assignment', 'service-booking-manager'), __('Connect WordPress users to the services they perform.', 'service-booking-manager'), __('WPBookingly → Staff Members', 'service-booking-manager'), array(
+						self::field(__('Existing user', 'service-booking-manager'), __('Links the staff profile to an existing WordPress account.', 'service-booking-manager')),
+						self::field(__('Username and password', 'service-booking-manager'), __('Creates login credentials when making a new staff account.', 'service-booking-manager')),
+						self::field(__('Email, first name, last name', 'service-booking-manager'), __('Contact and identity details used for the staff profile.', 'service-booking-manager')),
+						self::field(__('Profile image', 'service-booking-manager'), __('Picture displayed for the staff member where the selected layout supports it.', 'service-booking-manager')),
+						self::field(__('Assigned services', 'service-booking-manager'), __('Limits the services for which this staff member can be selected.', 'service-booking-manager')),
+						self::field(__('Holiday behavior', 'service-booking-manager'), __('Controls whether staff-specific unavailable dates modify booking availability.', 'service-booking-manager')),
+					), array('url_key' => 'staff', 'keywords' => 'staff user employee assign profile')),
+					self::topic('free-staff-schedule', __('Staff availability and dashboard', 'service-booking-manager'), __('Set individual hours and manage appointments without changing the service schedule.', 'service-booking-manager'), __('WPBookingly → Staff Members → Edit; staff users open their dashboard', 'service-booking-manager'), array(
+						self::field(__('Date type and active range', 'service-booking-manager'), __('Defines the staff member’s repeating or date-specific availability.', 'service-booking-manager')),
+						self::field(__('Off days and dates', 'service-booking-manager'), __('Blocks personal leave and other staff-only absences.', 'service-booking-manager')),
+						self::field(__('Weekday hours and breaks', 'service-booking-manager'), __('Sets personal working and break times.', 'service-booking-manager')),
+						self::field(__('Appointment filters', 'service-booking-manager'), __('Finds bookings by date, service, or status in the staff dashboard.', 'service-booking-manager')),
+						self::field(__('Reschedule date and time', 'service-booking-manager'), __('Moves an eligible appointment to another available slot.', 'service-booking-manager')),
+						self::field(__('Profile contact and preferences', 'service-booking-manager'), __('Lets staff maintain name, email, phone, address, city, password, and working preferences.', 'service-booking-manager')),
+					), array('url_key' => 'staff', 'keywords' => 'staff schedule holiday dashboard appointment reschedule profile')),
+				)),
+
+				self::section('free-booking', __('Booking Experience', 'service-booking-manager'), __('Understand the customer journey and the controls that affect it.', 'service-booking-manager'), 'booking', array(
+					self::topic('free-booking-options', __('Selection and customer dashboard', 'service-booking-manager'), __('Control how customers choose and later manage bookings.', 'service-booking-manager'), __('Edit Service and the customer account/dashboard pages', 'service-booking-manager'), array(
+						self::field(__('Multiple categories', 'service-booking-manager'), __('Shows several category groups in one booking flow.', 'service-booking-manager')),
+						self::field(__('Multiple services', 'service-booking-manager'), __('Allows several compatible choices in one booking.', 'service-booking-manager')),
+						self::field(__('Sticky booking widget', 'service-booking-manager'), __('Keeps the booking panel visible while a customer scrolls on supported layouts.', 'service-booking-manager')),
+						self::field(__('Single-page checkout', 'service-booking-manager'), __('Keeps supported selection and checkout steps together for a shorter journey.', 'service-booking-manager')),
+						self::field(__('Cancel / reschedule', 'service-booking-manager'), __('Customer actions are allowed only when status and lead-time rules permit them.', 'service-booking-manager')),
+						self::field(__('Waiting list', 'service-booking-manager'), __('The codebase contains waiting-list settings, but the current service-settings tab is not exposed; do not rely on it until a reachable control is provided.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'customer dashboard cancel reschedule waiting list multiple sticky checkout')),
+				)),
+
+				self::section('free-payments', __('Payments & Checkout', 'service-booking-manager'), __('Choose a checkout route and understand payment-related settings.', 'service-booking-manager'), 'payment', array(
+					self::topic('free-payment-mode', __('WooCommerce and payment mode', 'service-booking-manager'), __('Choose the order system that matches your site.', 'service-booking-manager'), __('WPBookingly → Settings → Payment Settings', 'service-booking-manager'), array(
+						self::field(__('WooCommerce payment mode', 'service-booking-manager'), __('Sends bookings through WooCommerce checkout, gateways, taxes, emails, and order management.', 'service-booking-manager'), __('Use this when your site already relies on WooCommerce gateways or order workflows.', 'service-booking-manager')),
+						self::field(__('Custom/native payment mode', 'service-booking-manager'), __('Uses WPBookingly’s native checkout. Its Stripe, PayPal, and offline gateway controls require Pro.', 'service-booking-manager')),
+						self::field(__('Checkout field controls', 'service-booking-manager'), __('WooCommerce billing, shipping, account, and order field visibility follows the available checkout settings screen.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'woocommerce payment mode gateway checkout order')),
+					self::topic('free-partial-payment', __('Partial payment', 'service-booking-manager'), __('Collect a deposit first and leave a recorded balance for later payment.', 'service-booking-manager'), __('WPBookingly → Settings → Payment Settings → Partial Payment', 'service-booking-manager'), array(
+						self::field(__('Enable partial payment', 'service-booking-manager'), __('Allows an initial amount smaller than the full booking total.', 'service-booking-manager')),
+						self::field(__('Deposit type', 'service-booking-manager'), __('Chooses whether the first payment is a percentage or fixed amount where offered.', 'service-booking-manager')),
+						self::field(__('Deposit amount', 'service-booking-manager'), __('Defines the amount collected during initial checkout.', 'service-booking-manager')),
+						self::field(__('Balance payment', 'service-booking-manager'), __('The remaining amount must be collected and recorded through the supported order/customer workflow.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'partial payment deposit balance due first payment')),
+				)),
+
+				self::section('free-coupons', __('Coupons', 'service-booking-manager'), __('Create controlled promotions without unintentionally discounting every booking.', 'service-booking-manager'), 'coupon', array(
+					self::topic('free-coupon-fields', __('Every coupon setting', 'service-booking-manager'), __('Define the offer, eligibility, schedule, staff, and usage limits.', 'service-booking-manager'), __('WPBookingly → Coupons → Add New or Edit', 'service-booking-manager'), array(
+						self::field(__('Coupon name and status', 'service-booking-manager'), __('Internal campaign name and whether the coupon is active or draft.', 'service-booking-manager')),
+						self::field(__('Coupon code', 'service-booking-manager'), __('The exact code customers enter; use a short memorable value.', 'service-booking-manager')),
+						self::field(__('Description', 'service-booking-manager'), __('Internal explanation of the promotion.', 'service-booking-manager')),
+						self::field(__('Start and expiry date', 'service-booking-manager'), __('Limits the calendar period in which the code can be used.', 'service-booking-manager')),
+						self::field(__('Discount type and value', 'service-booking-manager'), __('Chooses a percentage or fixed reduction and its amount.', 'service-booking-manager')),
+						self::field(__('Maximum discount', 'service-booking-manager'), __('Caps a percentage discount where this control is displayed.', 'service-booking-manager')),
+						self::field(__('Service scope', 'service-booking-manager'), __('Applies the code to all services or only selected services.', 'service-booking-manager')),
+						self::field(__('Minimum / maximum spend', 'service-booking-manager'), __('Requires the booking total to fall inside an allowed range.', 'service-booking-manager')),
+						self::field(__('Individual use / sale restrictions', 'service-booking-manager'), __('Prevents incompatible promotion combinations where supported.', 'service-booking-manager')),
+						self::field(__('Booking-day restriction', 'service-booking-manager'), __('Restricts the weekday on which the booked service occurs.', 'service-booking-manager')),
+						self::field(__('Date mode and dates', 'service-booking-manager'), __('Includes or excludes specific booking dates.', 'service-booking-manager')),
+						self::field(__('Time mode, bucket, and range', 'service-booking-manager'), __('Limits coupon use to selected times of day or a custom time range.', 'service-booking-manager')),
+						self::field(__('Staff scope and selected staff', 'service-booking-manager'), __('Restricts the offer to bookings handled by particular staff members.', 'service-booking-manager')),
+						self::field(__('Total usage limit', 'service-booking-manager'), __('Maximum successful uses across all customers.', 'service-booking-manager')),
+						self::field(__('Per-customer usage limit', 'service-booking-manager'), __('Maximum successful uses for one customer.', 'service-booking-manager')),
+					), array('url_key' => 'coupons', 'keywords' => 'coupon promo code discount restriction schedule staff limit')),
+				)),
+
+				self::section('free-reviews', __('Reviews & Follow-up', 'service-booking-manager'), __('Manage feedback and confirm customers receive the expected communication.', 'service-booking-manager'), 'review', array(
+					self::topic('free-reviews-email', __('Reviews and email follow-up', 'service-booking-manager'), __('Moderate feedback and diagnose missing customer messages.', 'service-booking-manager'), __('WPBookingly → Reviews; order and WordPress email settings', 'service-booking-manager'), array(
+						self::field(__('Review filters', 'service-booking-manager'), __('Narrow feedback by available service, rating, or moderation state.', 'service-booking-manager')),
+						self::field(__('Moderation actions', 'service-booking-manager'), __('Approve, hide, or otherwise manage feedback using the controls displayed.', 'service-booking-manager')),
+						self::field(__('Email delivery', 'service-booking-manager'), __('Booking messages depend on the chosen payment flow, WordPress mail delivery, and valid recipient addresses.', 'service-booking-manager'), __('Use an SMTP/mail logging plugin when messages do not arrive consistently.', 'service-booking-manager')),
+					), array('url_key' => 'reviews', 'keywords' => 'review rating moderation follow up email notification smtp')),
+				)),
+
+				self::section('free-analytics', __('Analytics & CSV', 'service-booking-manager'), __('Read booking performance and export results for reporting.', 'service-booking-manager'), 'analytics', array(
+					self::topic('free-analytics-dashboard', __('Dashboard filters, metrics, charts, and export', 'service-booking-manager'), __('Turn booking records into useful operational information.', 'service-booking-manager'), __('WPBookingly → Analytics', 'service-booking-manager'), array(
+						self::field(__('Date range', 'service-booking-manager'), __('Limits calculations to the selected booking or reporting period.', 'service-booking-manager')),
+						self::field(__('Service filter', 'service-booking-manager'), __('Shows results for all services or one selected service.', 'service-booking-manager')),
+						self::field(__('Status filter', 'service-booking-manager'), __('Includes only records in the chosen booking/order state.', 'service-booking-manager')),
+						self::field(__('Summary metrics and charts', 'service-booking-manager'), __('Present booking volume, revenue, service, and trend information available in the dashboard.', 'service-booking-manager')),
+						self::field(__('CSV export', 'service-booking-manager'), __('Downloads the filtered data for spreadsheets and external reporting.', 'service-booking-manager')),
+					), array('url_key' => 'analytics', 'keywords' => 'analytics dashboard report revenue chart csv export filters')),
+				)),
+
+				self::section('free-privacy', __('GDPR & Privacy', 'service-booking-manager'), __('Request consent clearly and handle customer privacy requests responsibly.', 'service-booking-manager'), 'privacy', array(
+					self::topic('free-gdpr-settings', __('Privacy and consent settings', 'service-booking-manager'), __('Configure the customer-facing privacy messages.', 'service-booking-manager'), __('WPBookingly → Settings → GDPR / Privacy', 'service-booking-manager'), array(
+						self::field(__('Enable GDPR', 'service-booking-manager'), __('Turns the plugin’s privacy/consent presentation on.', 'service-booking-manager')),
+						self::field(__('Cookie banner message', 'service-booking-manager'), __('Explains why the site uses relevant cookies.', 'service-booking-manager')),
+						self::field(__('Accept and reject text', 'service-booking-manager'), __('Labels the customer’s cookie choices.', 'service-booking-manager')),
+						self::field(__('Privacy policy page', 'service-booking-manager'), __('Links customers to the site’s full privacy policy.', 'service-booking-manager')),
+						self::field(__('Privacy consent text', 'service-booking-manager'), __('Explains agreement to the privacy policy during booking.', 'service-booking-manager')),
+						self::field(__('Data consent text', 'service-booking-manager'), __('Explains why booking details are collected and processed.', 'service-booking-manager')),
+						self::field(__('Privacy requests', 'service-booking-manager'), __('Use the available request screen to locate and track supported customer privacy requests.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'gdpr privacy cookie consent request policy data')),
+				)),
+
+				self::section('free-style', __('Labels, URLs & Styling', 'service-booking-manager'), __('Match the booking interface to your language, brand, and WordPress structure.', 'service-booking-manager'), 'style', array(
+					self::topic('free-global-display', __('All global labels and appearance fields', 'service-booking-manager'), __('Customize terminology, permalinks, formats, media behavior, and colors.', 'service-booking-manager'), __('WPBookingly → Settings → General / Display / Style', 'service-booking-manager'), array(
+						self::field(__('Service label, slug, and icon', 'service-booking-manager'), __('Changes the admin/public service name, URL base, and associated icon.', 'service-booking-manager'), __('After changing a slug, save WordPress Permalinks once.', 'service-booking-manager')),
+						self::field(__('Category label and slug', 'service-booking-manager'), __('Changes category wording and its URL base.', 'service-booking-manager')),
+						self::field(__('Organizer label and slug', 'service-booking-manager'), __('Changes staff/organizer terminology and URL base where used.', 'service-booking-manager')),
+						self::field(__('Category, subcategory, and service text', 'service-booking-manager'), __('Replaces customer-facing selection instructions.', 'service-booking-manager')),
+						self::field(__('Disable block editor', 'service-booking-manager'), __('Uses the plugin’s intended classic/custom service editing experience.', 'service-booking-manager')),
+						self::field(__('Full and short date format', 'service-booking-manager'), __('Controls how dates appear in long and compact contexts.', 'service-booking-manager')),
+						self::field(__('24-hour time format', 'service-booking-manager'), __('Switches supported time displays between 24-hour and 12-hour notation.', 'service-booking-manager')),
+						self::field(__('Slider type and style', 'service-booking-manager'), __('Chooses the available gallery/slider behavior and visual treatment.', 'service-booking-manager')),
+						self::field(__('Indicator visibility and type', 'service-booking-manager'), __('Controls navigation indicators shown with service media.', 'service-booking-manager')),
+						self::field(__('Showcase visibility and position', 'service-booking-manager'), __('Controls whether and where the media showcase is presented.', 'service-booking-manager')),
+						self::field(__('Popup image/icon indicator', 'service-booking-manager'), __('Chooses cues used for opening media in a popup.', 'service-booking-manager')),
+						self::field(__('Theme and alternate color', 'service-booking-manager'), __('Applies the primary and supporting brand colors to supported booking components.', 'service-booking-manager')),
+						self::field(__('Custom CSS', 'service-booking-manager'), __('Adds advanced site-specific style overrides.', 'service-booking-manager'), __('Use narrowly scoped selectors and keep a copy before changing themes.', 'service-booking-manager')),
+					), array('url_key' => 'settings', 'keywords' => 'label slug permalink date time slider indicator showcase popup theme color css')),
+				)),
+
+				self::section('free-troubleshooting', __('Troubleshooting', 'service-booking-manager'), __('Resolve the most common setup problems in a safe order.', 'service-booking-manager'), 'tools', array(
+					self::topic('free-common-problems', __('No slots, checkout, email, 404, and staff issues', 'service-booking-manager'), __('Use these checks before changing or reinstalling anything.', 'service-booking-manager'), __('WPBookingly → Status, Settings, Service editor, and Staff Members', 'service-booking-manager'), array(
+						self::field(__('No available slots', 'service-booking-manager'), __('Check future dates, weekday hours, breaks, off dates, slot length, capacity, buffer time, staff assignment, and booked statuses.', 'service-booking-manager')),
+						self::field(__('Checkout or payment fails', 'service-booking-manager'), __('Confirm the selected payment mode, WooCommerce pages/gateways when used, currency, HTTPS, and gateway credentials for enabled native gateways.', 'service-booking-manager')),
+						self::field(__('Emails do not arrive', 'service-booking-manager'), __('Verify recipient addresses, order status, WordPress mail delivery, spam folders, and SMTP logs.', 'service-booking-manager')),
+						self::field(__('Service page returns 404', 'service-booking-manager'), __('Open Settings → Permalinks and save once, especially after changing a service or taxonomy slug.', 'service-booking-manager')),
+						self::field(__('Staff member not selectable', 'service-booking-manager'), __('Confirm the user is assigned to the service and has availability overlapping the service date and time.', 'service-booking-manager')),
+					), array('url_key' => 'status', 'keywords' => 'troubleshoot error no slots checkout payment email 404 permalink staff unavailable')),
+				)),
+			);
+		}
+	}
+}

--- a/assets/admin/mpwpb-help-guide.css
+++ b/assets/admin/mpwpb-help-guide.css
@@ -1,0 +1,166 @@
+.mpwpb-guide {
+	--mpwpb-navy: #132238;
+	--mpwpb-navy-2: #1d3452;
+	--mpwpb-amber: #f2a900;
+	--mpwpb-amber-dark: #b97800;
+	--mpwpb-canvas: #f3f5f8;
+	--mpwpb-ink: #1c2938;
+	--mpwpb-muted: #637083;
+	--mpwpb-line: #dce2ea;
+	--mpwpb-free: #18794e;
+	--mpwpb-pro: #7a4bc3;
+	max-width: 1500px;
+	margin: 20px 20px 60px 0;
+	color: var(--mpwpb-ink);
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.mpwpb-guide *, .mpwpb-guide *::before, .mpwpb-guide *::after { box-sizing: border-box; }
+
+.mpwpb-guide__hero {
+	position: relative;
+	overflow: hidden;
+	padding: 42px 44px 38px;
+	border-radius: 18px;
+	background:
+		radial-gradient(circle at 86% 12%, rgba(242,169,0,.22), transparent 27%),
+		linear-gradient(135deg, #101d30 0%, #1d3452 100%);
+	color: #fff;
+	box-shadow: 0 18px 45px rgba(19,34,56,.18);
+}
+
+.mpwpb-guide__hero::after {
+	content: "";
+	position: absolute;
+	right: -55px;
+	top: -100px;
+	width: 300px;
+	height: 300px;
+	border: 1px solid rgba(255,255,255,.09);
+	border-radius: 50%;
+	box-shadow: 0 0 0 34px rgba(255,255,255,.025), 0 0 0 72px rgba(255,255,255,.02);
+}
+
+.mpwpb-guide__hero-copy { position: relative; z-index: 1; max-width: 820px; }
+.mpwpb-guide__eyebrow { color: #ffd77c; font-size: 12px; font-weight: 800; letter-spacing: .11em; text-transform: uppercase; }
+.mpwpb-guide__hero h1 { margin: 8px 0 10px; color: #fff; font-size: clamp(30px, 4vw, 46px); line-height: 1.08; letter-spacing: -.035em; }
+.mpwpb-guide__hero-copy > p { max-width: 720px; margin: 0; color: #d5dfec; font-size: 16px; line-height: 1.65; }
+.mpwpb-guide__edition { position: absolute; z-index: 2; top: 30px; right: 32px; display: flex; align-items: center; gap: 7px; padding: 8px 12px; border: 1px solid rgba(255,255,255,.17); border-radius: 999px; background: rgba(255,255,255,.09); font-size: 12px; font-weight: 700; backdrop-filter: blur(8px); }
+.mpwpb-guide__edition .dashicons { color: #ffd062; font-size: 18px; width: 18px; height: 18px; }
+
+.mpwpb-guide__search-wrap { position: relative; z-index: 2; max-width: 760px; margin-top: 28px; }
+.mpwpb-guide__search-wrap label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
+.mpwpb-guide__search-wrap > .dashicons { position: absolute; left: 17px; top: 15px; color: #66768b; }
+.mpwpb-guide__search-wrap input[type="search"] { width: 100%; min-height: 52px; padding: 10px 50px 10px 49px; border: 0; border-radius: 12px; background: #fff; color: var(--mpwpb-ink); font-size: 15px; box-shadow: 0 12px 30px rgba(0,0,0,.15); }
+.mpwpb-guide__search-wrap input[type="search"]:focus { outline: 3px solid rgba(242,169,0,.65); box-shadow: 0 12px 30px rgba(0,0,0,.15); }
+.mpwpb-guide__search-wrap kbd { position: absolute; right: 15px; top: 14px; padding: 3px 8px; border: 1px solid #d8dee7; border-bottom-width: 2px; border-radius: 5px; background: #f7f8fa; color: #6d7887; font: 12px/18px inherit; }
+
+.mpwpb-guide__notice { margin-top: 16px; padding: 13px 16px; border-left: 4px solid var(--mpwpb-amber); border-radius: 7px; background: #fff8e5; color: #664b0b; }
+.mpwpb-guide__quick { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; margin: 18px 0; overflow: hidden; border: 1px solid var(--mpwpb-line); border-radius: 13px; background: var(--mpwpb-line); box-shadow: 0 6px 22px rgba(19,34,56,.06); }
+.mpwpb-guide__quick a { display: flex; align-items: center; gap: 11px; min-height: 68px; padding: 13px 15px; background: #fff; color: var(--mpwpb-ink); text-decoration: none; transition: background .18s ease, color .18s ease; }
+.mpwpb-guide__quick a:hover, .mpwpb-guide__quick a:focus { background: #fff9e9; color: #7a5200; }
+.mpwpb-guide__quick strong { display: grid; flex: 0 0 28px; width: 28px; height: 28px; place-items: center; border-radius: 50%; background: #fff1c7; color: #825800; font-size: 12px; }
+.mpwpb-guide__quick span { font-weight: 700; line-height: 1.3; }
+
+.mpwpb-guide__toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 18px; padding: 11px 13px; border: 1px solid var(--mpwpb-line); border-radius: 11px; background: #fff; }
+.mpwpb-guide__filters { display: flex; gap: 4px; padding: 3px; border-radius: 8px; background: #edf1f5; }
+.mpwpb-guide__filters button, .mpwpb-guide__expand, .mpwpb-guide__empty button { min-height: 34px; padding: 5px 13px; border: 0; border-radius: 6px; background: transparent; color: #47566a; font-weight: 700; cursor: pointer; }
+.mpwpb-guide__filters button.is-active { background: #fff; color: var(--mpwpb-navy); box-shadow: 0 1px 5px rgba(19,34,56,.14); }
+.mpwpb-guide__expand { border: 1px solid var(--mpwpb-line); background: #fff; }
+.mpwpb-guide__results { margin-left: auto; color: var(--mpwpb-muted); font-size: 13px; }
+.mpwpb-guide__mobile-nav { display: none; }
+
+.mpwpb-guide__layout { display: grid; grid-template-columns: 260px minmax(0, 1fr); gap: 24px; align-items: start; }
+.mpwpb-guide__nav { position: sticky; top: 48px; max-height: calc(100vh - 70px); overflow: auto; padding: 12px; border: 1px solid var(--mpwpb-line); border-radius: 13px; background: #fff; box-shadow: 0 7px 25px rgba(19,34,56,.05); }
+.mpwpb-guide__nav > p { margin: 5px 10px 10px; color: #7b8797; font-size: 11px; font-weight: 800; letter-spacing: .08em; text-transform: uppercase; }
+.mpwpb-guide__nav a { display: grid; grid-template-columns: 25px 1fr auto; gap: 7px; align-items: center; min-height: 43px; margin: 2px 0; padding: 8px 9px; border-radius: 8px; color: #405067; text-decoration: none; }
+.mpwpb-guide__nav a:hover, .mpwpb-guide__nav a:focus, .mpwpb-guide__nav a.is-active { background: #edf3f8; color: var(--mpwpb-navy); }
+.mpwpb-guide__nav a.is-active { box-shadow: inset 3px 0 var(--mpwpb-amber); }
+.mpwpb-guide__nav .dashicons { color: #718097; font-size: 18px; width: 18px; height: 18px; }
+.mpwpb-guide__nav small { padding: 2px 5px; border-radius: 4px; background: #e9f5ee; color: var(--mpwpb-free); font-size: 8px; font-weight: 800; }
+.mpwpb-guide__nav a[data-tier="pro"] small { background: #f0eafa; color: var(--mpwpb-pro); }
+
+.mpwpb-guide__content { min-width: 0; }
+.mpwpb-guide__section { scroll-margin-top: 48px; margin: 0 0 30px; }
+.mpwpb-guide__section[hidden], .mpwpb-guide__topic[hidden], .mpwpb-guide__nav a[hidden] { display: none !important; }
+.mpwpb-guide__section-head { display: flex; gap: 14px; align-items: flex-start; margin-bottom: 13px; padding: 4px 4px 2px; }
+.mpwpb-guide__section-icon { display: grid; flex: 0 0 43px; width: 43px; height: 43px; place-items: center; border-radius: 11px; background: var(--mpwpb-navy); color: #fff; box-shadow: 0 7px 14px rgba(19,34,56,.15); }
+.mpwpb-guide__section-icon .dashicons { font-size: 22px; width: 22px; height: 22px; }
+.mpwpb-guide__section-head h2 { display: inline; margin: 0 0 4px 7px; color: var(--mpwpb-navy); font-size: 22px; line-height: 1.25; }
+.mpwpb-guide__section-head p { margin: 5px 0 0; color: var(--mpwpb-muted); line-height: 1.55; }
+.mpwpb-guide__tier { display: inline-block; padding: 3px 6px; border-radius: 5px; background: #e9f5ee; color: var(--mpwpb-free); font-size: 9px; font-weight: 800; letter-spacing: .04em; text-transform: uppercase; vertical-align: 3px; }
+.mpwpb-guide__tier--pro { background: #f0eafa; color: var(--mpwpb-pro); }
+
+.mpwpb-guide__topics { display: grid; gap: 10px; }
+.mpwpb-guide__topic { scroll-margin-top: 60px; overflow: hidden; border: 1px solid var(--mpwpb-line); border-radius: 12px; background: #fff; box-shadow: 0 5px 20px rgba(19,34,56,.045); }
+.mpwpb-guide__topic:target { border-color: var(--mpwpb-amber); box-shadow: 0 0 0 3px rgba(242,169,0,.14); }
+.mpwpb-guide__topic-toggle { display: flex; width: 100%; align-items: center; justify-content: space-between; gap: 18px; padding: 18px 20px; border: 0; background: #fff; color: var(--mpwpb-ink); text-align: left; cursor: pointer; }
+.mpwpb-guide__topic-toggle > span:first-child { display: grid; grid-template-columns: auto 1fr; gap: 2px 8px; align-items: center; }
+.mpwpb-guide__topic-toggle strong { font-size: 16px; line-height: 1.35; }
+.mpwpb-guide__topic-toggle small { grid-column: 1 / -1; margin-top: 3px; color: var(--mpwpb-muted); font-size: 13px; line-height: 1.5; }
+.mpwpb-guide__topic-toggle > .dashicons { transition: transform .18s ease; }
+.mpwpb-guide__topic.is-open .mpwpb-guide__topic-toggle > .dashicons { transform: rotate(180deg); }
+.mpwpb-guide.is-enhanced .mpwpb-guide__topic-body { display: none; }
+.mpwpb-guide.is-enhanced .mpwpb-guide__topic.is-open .mpwpb-guide__topic-body { display: block; }
+.mpwpb-guide__topic-body { padding: 0 20px 20px; border-top: 1px solid #edf0f4; }
+.mpwpb-guide__where { display: flex; gap: 10px; margin: 16px 0; padding: 12px 14px; border-radius: 9px; background: #f2f5f8; }
+.mpwpb-guide__where .dashicons { color: var(--mpwpb-amber-dark); }
+.mpwpb-guide__where strong, .mpwpb-guide__where span { display: block; }
+.mpwpb-guide__where strong { margin-bottom: 2px; color: #33445a; font-size: 11px; letter-spacing: .04em; text-transform: uppercase; }
+.mpwpb-guide__where span { color: #536276; }
+.mpwpb-guide__callout { display: flex; gap: 10px; margin: 14px 0; padding: 12px 14px; border-left: 3px solid var(--mpwpb-amber); border-radius: 6px; background: #fff8e5; color: #664b0b; }
+.mpwpb-guide__callout p { margin: 0; line-height: 1.55; }
+.mpwpb-guide__steps { display: grid; gap: 8px; margin: 16px 0; padding: 0; list-style: none; counter-reset: mpwpb-step; }
+.mpwpb-guide__steps li { position: relative; min-height: 30px; padding: 5px 0 5px 40px; line-height: 1.55; counter-increment: mpwpb-step; }
+.mpwpb-guide__steps li::before { content: counter(mpwpb-step); position: absolute; left: 0; top: 1px; display: grid; width: 29px; height: 29px; place-items: center; border-radius: 50%; background: var(--mpwpb-navy); color: #fff; font-size: 11px; font-weight: 800; }
+.mpwpb-guide__fields h3 { margin: 22px 0 8px; font-size: 13px; letter-spacing: .04em; text-transform: uppercase; }
+.mpwpb-guide__fields dl { margin: 0; overflow: hidden; border: 1px solid var(--mpwpb-line); border-radius: 9px; }
+.mpwpb-guide__fields dl > div { display: grid; grid-template-columns: minmax(165px, 28%) 1fr; border-top: 1px solid var(--mpwpb-line); }
+.mpwpb-guide__fields dl > div:first-child { border-top: 0; }
+.mpwpb-guide__fields dt, .mpwpb-guide__fields dd { margin: 0; padding: 12px 14px; line-height: 1.5; }
+.mpwpb-guide__fields dt { background: #f6f8fa; color: #314157; font-weight: 700; }
+.mpwpb-guide__fields dd { color: #506075; }
+.mpwpb-guide__fields dd small { display: block; margin-top: 5px; color: #8a6108; font-style: italic; }
+.mpwpb-guide__actions { display: flex; gap: 10px; align-items: center; margin-top: 17px; }
+.mpwpb-guide__open, .mpwpb-guide__copy { display: inline-flex; min-height: 36px; align-items: center; gap: 6px; padding: 7px 13px; border-radius: 7px; font-weight: 700; text-decoration: none; cursor: pointer; }
+.mpwpb-guide__open { border: 1px solid var(--mpwpb-navy); background: var(--mpwpb-navy); color: #fff; }
+.mpwpb-guide__open:hover, .mpwpb-guide__open:focus { background: var(--mpwpb-navy-2); color: #fff; }
+.mpwpb-guide__copy { border: 1px solid var(--mpwpb-line); background: #fff; color: #536176; }
+.mpwpb-guide__open .dashicons, .mpwpb-guide__copy .dashicons { font-size: 16px; width: 16px; height: 16px; }
+.mpwpb-guide mark { padding: 0 2px; border-radius: 2px; background: #ffe29a; color: inherit; }
+.mpwpb-guide__empty { padding: 55px 25px; border: 1px dashed #c9d1db; border-radius: 12px; background: #fff; text-align: center; }
+.mpwpb-guide__empty .dashicons { width: 36px; height: 36px; color: #8b98a8; font-size: 36px; }
+.mpwpb-guide__empty h2 { margin: 10px 0 5px; }
+.mpwpb-guide__empty p { color: var(--mpwpb-muted); }
+.mpwpb-guide__empty button { background: var(--mpwpb-navy); color: #fff; }
+
+.mpwpb-guide button:focus-visible, .mpwpb-guide a:focus-visible, .mpwpb-guide select:focus-visible { outline: 3px solid rgba(242,169,0,.58); outline-offset: 2px; }
+
+@media (max-width: 1100px) {
+	.mpwpb-guide__quick { grid-template-columns: repeat(3, 1fr); }
+	.mpwpb-guide__layout { grid-template-columns: 220px minmax(0, 1fr); gap: 18px; }
+	.mpwpb-guide__edition { position: relative; top: auto; right: auto; display: inline-flex; margin-top: 18px; }
+}
+
+@media (max-width: 782px) {
+	.mpwpb-guide { margin-right: 10px; }
+	.mpwpb-guide__hero { padding: 30px 24px; border-radius: 13px; }
+	.mpwpb-guide__quick { grid-template-columns: 1fr; }
+	.mpwpb-guide__quick a { min-height: 52px; }
+	.mpwpb-guide__toolbar { align-items: stretch; flex-wrap: wrap; }
+	.mpwpb-guide__mobile-nav { display: grid; flex: 1 0 100%; gap: 5px; }
+	.mpwpb-guide__mobile-nav label { font-weight: 700; }
+	.mpwpb-guide__mobile-nav select { width: 100%; max-width: none; min-height: 40px; }
+	.mpwpb-guide__layout { display: block; }
+	.mpwpb-guide__nav { display: none; }
+	.mpwpb-guide__results { flex: 1 0 100%; margin-left: 0; }
+	.mpwpb-guide__fields dl { border: 0; overflow: visible; }
+	.mpwpb-guide__fields dl > div { display: block; margin-bottom: 8px; overflow: hidden; border: 1px solid var(--mpwpb-line); border-radius: 8px; }
+	.mpwpb-guide__fields dt, .mpwpb-guide__fields dd { padding: 10px 12px; }
+	.mpwpb-guide__actions { align-items: stretch; flex-direction: column; }
+	.mpwpb-guide__open, .mpwpb-guide__copy { justify-content: center; width: 100%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.mpwpb-guide *, .mpwpb-guide *::before, .mpwpb-guide *::after { scroll-behavior: auto !important; transition: none !important; }
+}

--- a/assets/admin/mpwpb-help-guide.js
+++ b/assets/admin/mpwpb-help-guide.js
@@ -1,0 +1,171 @@
+(function () {
+	'use strict';
+
+	var guide = document.querySelector('.mpwpb-guide');
+	if (!guide) return;
+
+	var search = document.getElementById('mpwpb-guide-search');
+	var topics = Array.prototype.slice.call(guide.querySelectorAll('.mpwpb-guide__topic'));
+	var sections = Array.prototype.slice.call(guide.querySelectorAll('.mpwpb-guide__section'));
+	var filters = Array.prototype.slice.call(guide.querySelectorAll('.mpwpb-guide__filters button'));
+	var navLinks = Array.prototype.slice.call(guide.querySelectorAll('.mpwpb-guide__nav a'));
+	var resultText = document.getElementById('mpwpb-guide-results');
+	var live = document.getElementById('mpwpb-guide-live');
+	var empty = guide.querySelector('.mpwpb-guide__empty');
+	var expand = guide.querySelector('.mpwpb-guide__expand');
+	var sectionSelect = document.getElementById('mpwpb-guide-section-select');
+	var activeTier = 'all';
+
+	guide.classList.add('is-enhanced');
+
+	function normalize(value) {
+		return String(value || '').toLocaleLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/\s+/g, ' ').trim();
+	}
+
+	function words() {
+		return normalize(search.value).split(' ').filter(Boolean);
+	}
+
+	function setOpen(topic, open) {
+		var button = topic.querySelector('.mpwpb-guide__topic-toggle');
+		topic.classList.toggle('is-open', open);
+		if (button) button.setAttribute('aria-expanded', open ? 'true' : 'false');
+	}
+
+	function update() {
+		var query = words();
+		var visibleCount = 0;
+
+		topics.forEach(function (topic) {
+			var tierMatch = activeTier === 'all' || topic.dataset.tier === activeTier;
+			var haystack = normalize(topic.dataset.search);
+			var searchMatch = query.every(function (word) { return haystack.indexOf(word) !== -1; });
+			var show = tierMatch && searchMatch;
+			topic.hidden = !show;
+			if (show) {
+				visibleCount += 1;
+				if (query.length) setOpen(topic, true);
+			}
+		});
+
+		sections.forEach(function (section) {
+			var hasVisible = !!section.querySelector('.mpwpb-guide__topic:not([hidden])');
+			section.hidden = !hasVisible;
+			var nav = guide.querySelector('.mpwpb-guide__nav a[href="#' + section.id + '"]');
+			if (nav) nav.hidden = !hasVisible;
+		});
+
+		if (resultText) {
+			resultText.textContent = visibleCount === 1 ? '1 topic found' : visibleCount + ' topics found';
+		}
+		if (empty) empty.hidden = visibleCount !== 0;
+	}
+
+	topics.forEach(function (topic) {
+		var toggle = topic.querySelector('.mpwpb-guide__topic-toggle');
+		if (toggle) {
+			toggle.addEventListener('click', function () {
+				setOpen(topic, !topic.classList.contains('is-open'));
+			});
+		}
+	});
+
+	filters.forEach(function (button) {
+		button.addEventListener('click', function () {
+			activeTier = button.dataset.tier || 'all';
+			filters.forEach(function (item) {
+				var selected = item === button;
+				item.classList.toggle('is-active', selected);
+				item.setAttribute('aria-pressed', selected ? 'true' : 'false');
+			});
+			update();
+		});
+	});
+
+	if (search) search.addEventListener('input', update);
+
+	if (expand) {
+		expand.addEventListener('click', function () {
+			var shouldExpand = expand.dataset.expanded !== 'true';
+			topics.filter(function (topic) { return !topic.hidden; }).forEach(function (topic) { setOpen(topic, shouldExpand); });
+			expand.dataset.expanded = shouldExpand ? 'true' : 'false';
+			expand.textContent = shouldExpand ? 'Collapse all' : 'Expand all';
+		});
+	}
+
+	if (sectionSelect) {
+		sectionSelect.addEventListener('change', function () {
+			if (!sectionSelect.value) return;
+			var target = document.querySelector(sectionSelect.value);
+			if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		});
+	}
+
+	guide.querySelectorAll('.mpwpb-guide__copy').forEach(function (button) {
+		button.addEventListener('click', function () {
+			var url = window.location.href.split('#')[0] + '#' + button.dataset.topic;
+			var done = function (message) { if (live) live.textContent = message; };
+			if (navigator.clipboard && window.isSecureContext) {
+				navigator.clipboard.writeText(url).then(function () { done(window.mpwpbHelpGuide.copied); }).catch(function () { done(window.mpwpbHelpGuide.copyFailed); });
+			} else {
+				done(window.mpwpbHelpGuide.copyFailed);
+			}
+		});
+	});
+
+	if (empty) {
+		var clear = empty.querySelector('button');
+		if (clear) clear.addEventListener('click', function () { search.value = ''; activeTier = 'all'; filters[0].click(); search.focus(); });
+	}
+
+	document.addEventListener('keydown', function (event) {
+		var target = event.target;
+		var typing = /^(INPUT|TEXTAREA|SELECT|BUTTON|A)$/.test(target.tagName) || target.isContentEditable;
+		if (event.key === '/' && !typing) {
+			event.preventDefault();
+			search.focus();
+		}
+		if (event.key === 'Escape' && document.activeElement === search && search.value) {
+			search.value = '';
+			update();
+		}
+	});
+
+	function openHash() {
+		var id = window.location.hash.slice(1);
+		if (!id) return;
+		var target = document.getElementById(id);
+		if (target && target.classList.contains('mpwpb-guide__topic')) {
+			setOpen(target, true);
+			setTimeout(function () {
+				target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				var heading = target.querySelector('.mpwpb-guide__topic-toggle');
+				if (heading) heading.focus({ preventScroll: true });
+			}, 50);
+		} else if (id.indexOf('pro-') === 0 && guide.dataset.hasPro !== '1') {
+			var notice = document.getElementById('mpwpb-guide-pro-notice');
+			if (notice) {
+				notice.textContent = window.mpwpbHelpGuide.proRequired;
+				notice.hidden = false;
+			}
+		}
+	}
+
+	if ('IntersectionObserver' in window) {
+		var observer = new IntersectionObserver(function (entries) {
+			entries.forEach(function (entry) {
+				if (!entry.isIntersecting) return;
+				navLinks.forEach(function (link) {
+					var active = link.getAttribute('href') === '#' + entry.target.id;
+					link.classList.toggle('is-active', active);
+					if (active) link.setAttribute('aria-current', 'location'); else link.removeAttribute('aria-current');
+				});
+			});
+		}, { rootMargin: '-15% 0px -70% 0px' });
+		sections.forEach(function (section) { observer.observe(section); });
+	}
+
+	window.addEventListener('hashchange', openHash);
+	update();
+	openHash();
+}());


### PR DESCRIPTION
Register a single Help & Guide submenu beneath the WPBookingly service menu.

Add a searchable and responsive admin help center with quick-start navigation, tier filters, expandable topics, direct admin links, copyable deep links, keyboard support, and accessible mobile layouts.

Document Free service setup, availability, pricing, staff, checkout, coupons, reviews, analytics, privacy, display settings, and troubleshooting in customer-friendly language.

Expose the mpwpb_help_guide_sections filter so active extensions can contribute documentation without creating duplicate guide pages, and scope all new CSS and JavaScript assets to the guide screen.