### PR TITLE
Frontend/admin working-tree updates (analytics, checkout fields, recurring, GDPR, user dashboard)

### DIFF
--- a/Admin/MPWPB_Analytics_Dashboard.php
+++ b/Admin/MPWPB_Analytics_Dashboard.php
@@ -39,8 +39,8 @@ if (!class_exists('MPWPB_Analytics_Dashboard')) {
                 return;
             }
             
-            wp_enqueue_style('mpwpb-analytics-dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.css', array(), time());
-            wp_enqueue_script('mpwpb-analytics-dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.js', array('jquery', 'chartjs'), time(), true);
+            wp_enqueue_style('mpwpb-analytics-dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.css', array(), MPWPB_VERSION);
+            wp_enqueue_script('mpwpb-analytics-dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.js', array('jquery', 'chartjs'), MPWPB_VERSION, true);
         }
         
         /**

--- a/Admin/MPWPB_Wc_Checkout_Fields.php
+++ b/Admin/MPWPB_Wc_Checkout_Fields.php
@@ -68,14 +68,14 @@
 				$this->settings_options = get_option('mpwpb_custom_checkout_fields');
 			}
 			public function admin_enqueue() {
-				wp_enqueue_style('mpwpb_checkout', MPWPB_PLUGIN_URL . '/assets/checkout/css/mpwpb-pro-checkout.css', array(), time());
-				wp_enqueue_style('mpwpb_modal_custom', MPWPB_PLUGIN_URL . '/assets/checkout/css/mpwpb-modal-custom.css', array(), time());
-				wp_enqueue_script('mpwpb_checkout', MPWPB_PLUGIN_URL . '/assets/checkout/js/mpwpb-pro-checkout.js', array('jquery'), time(), true);
-				wp_enqueue_script('mpwpb_modal_fix', MPWPB_PLUGIN_URL . '/assets/checkout/js/mpwpb-modal-fix.js', array('jquery', 'mpwpb_checkout'), time(), true);
+				wp_enqueue_style('mpwpb_checkout', MPWPB_PLUGIN_URL . '/assets/checkout/css/mpwpb-pro-checkout.css', array(), MPWPB_VERSION);
+				wp_enqueue_style('mpwpb_modal_custom', MPWPB_PLUGIN_URL . '/assets/checkout/css/mpwpb-modal-custom.css', array(), MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_checkout', MPWPB_PLUGIN_URL . '/assets/checkout/js/mpwpb-pro-checkout.js', array('jquery'), MPWPB_VERSION, true);
+				wp_enqueue_script('mpwpb_modal_fix', MPWPB_PLUGIN_URL . '/assets/checkout/js/mpwpb-modal-fix.js', array('jquery', 'mpwpb_checkout'), MPWPB_VERSION, true);
 			}
 			public function frontend_enqueue() {
-				wp_enqueue_style('mpwpb_checkout_front_style', MPWPB_PLUGIN_URL . '/assets/checkout/front/css/mpwpb-pro-checkout-front-style.css', array(), time());
-				wp_enqueue_script('mpwpb_checkout_front_script', MPWPB_PLUGIN_URL . '/assets/checkout/front/js/mpwpb-pro-checkout-front-script.js', array('jquery'), time(), true);
+				wp_enqueue_style('mpwpb_checkout_front_style', MPWPB_PLUGIN_URL . '/assets/checkout/front/css/mpwpb-pro-checkout-front-style.css', array(), MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_checkout_front_script', MPWPB_PLUGIN_URL . '/assets/checkout/front/js/mpwpb-pro-checkout-front-script.js', array('jquery'), MPWPB_VERSION, true);
 			}
 			public function checkout_menu() {
 				$cpt = MPWPB_Function::get_cpt();

--- a/Admin/settings/Recurring_Booking.php
+++ b/Admin/settings/Recurring_Booking.php
@@ -185,7 +185,8 @@ if (!class_exists('MPWPB_Recurring_Booking_Settings')) {
                                 </div>
                             </li>';
 
-                            $selected_html_right .= '<li class="mpwpd_service_date" data-cart-date-time="'.esc_attr($date).'"><div class="mpwpb_seleted_date_text">'.esc_html($formattedDate).'</div></li>';
+							// Unavailable candidates are informational only and must not be
+							// copied into the cart's selected-date collection.
                         }
                     }
                 }

--- a/Frontend/MPWPB_Ajax_File_Upload.php
+++ b/Frontend/MPWPB_Ajax_File_Upload.php
@@ -33,7 +33,7 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
          */
         public function enqueue_scripts() {
             if (MPWPB_Global_Function::is_mpwpb_checkout_page()) {
-                wp_enqueue_script('mpwpb-file-upload', MPWPB_PLUGIN_URL . '/assets/checkout/front/js/mpwpb-file-upload.js', array('jquery'), time(), true);
+                wp_enqueue_script('mpwpb-file-upload', MPWPB_PLUGIN_URL . '/assets/checkout/front/js/mpwpb-file-upload.js', array('jquery'), MPWPB_VERSION, true);
                 wp_localize_script('mpwpb-file-upload', 'mpwpb_file_upload', array(
                     'ajax_url' => admin_url('admin-ajax.php'),
                     'nonce' => wp_create_nonce('mpwpb_file_upload_nonce'),
@@ -87,7 +87,10 @@ if (!class_exists('MPWPB_Ajax_File_Upload')) {
             // Create upload overrides
             $upload_overrides = array(
                 'test_form' => false,
-                'mimes' => $this->allowed_mime_types
+				'mimes' => $this->allowed_mime_types,
+				'unique_filename_callback' => static function($dir, $name, $ext) {
+					return 'mpwpb-' . wp_generate_password(32, false, false) . $ext;
+				},
             );
             
             // Use WordPress's built-in file handling

--- a/Frontend/MPWPB_Gdpr_Cookie_Banner.php
+++ b/Frontend/MPWPB_Gdpr_Cookie_Banner.php
@@ -22,8 +22,8 @@
 				add_action('wp_footer', array($this, 'render_banner'));
 			}
 			public function enqueue(): void {
-				wp_enqueue_style('mpwpb_gdpr_cookie_banner', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-gdpr-cookie-banner.css', array(), time());
-				wp_enqueue_script('mpwpb_gdpr_cookie_banner', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-gdpr-cookie-banner.js', array('jquery'), time(), true);
+				wp_enqueue_style('mpwpb_gdpr_cookie_banner', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-gdpr-cookie-banner.css', array(), MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_gdpr_cookie_banner', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-gdpr-cookie-banner.js', array('jquery'), MPWPB_VERSION, true);
 				wp_localize_script('mpwpb_gdpr_cookie_banner', 'mpwpb_gdpr', array(
 					'message' => MPWPB_Global_Function::get_gdpr_setting('cookie_banner_message', esc_html__('We use cookies to remember your booking details and improve your experience. Do you accept?', 'service-booking-manager')),
 					'accept_text' => MPWPB_Global_Function::get_gdpr_setting('cookie_accept_text', esc_html__('Accept', 'service-booking-manager')),

--- a/Frontend/MPWPB_Recurring_Booking.php
+++ b/Frontend/MPWPB_Recurring_Booking.php
@@ -13,10 +13,6 @@ if (!class_exists('MPWPB_Recurring_Booking')) {
             // Enqueue scripts and styles
             add_action('wp_enqueue_scripts', array($this, 'enqueue_scripts'));
             
-            // AJAX handlers
-            add_action('wp_ajax_mpwpb_save_recurring_booking', array($this, 'generate_recurring_dates'));
-            add_action('wp_ajax_nopriv_mpwpb_save_recurring_booking', array($this, 'generate_recurring_dates'));
-            
             // Filter cart item data to include recurring booking information
             add_filter('mpwpb_add_cart_item', array($this, 'add_recurring_data_to_cart'), 10, 2);
             
@@ -35,7 +31,12 @@ if (!class_exists('MPWPB_Recurring_Booking')) {
          */
         public function enqueue_scripts() {
 //            if (is_singular(MPWPB_Function::get_cpt()) || (is_a(get_post(), 'WP_Post') && has_shortcode(get_post()->post_content, 'mpwpb-registration'))) {
-                global $post;
+				global $post;
+				$is_service = is_singular(MPWPB_Function::get_cpt());
+				$has_registration = is_a($post, 'WP_Post') && has_shortcode($post->post_content, 'mpwpb-registration');
+				if (!$is_service && !$has_registration) {
+					return;
+				}
 
                 wp_enqueue_script('mpwpb-recurring-booking', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_recurring_booking.js', array('jquery'),  true);
                 wp_enqueue_style('mpwpb-recurring-booking', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_recurring_booking.css', array(), true);

--- a/Frontend/MPWPB_User_Dashboard.php
+++ b/Frontend/MPWPB_User_Dashboard.php
@@ -28,8 +28,8 @@ if (!class_exists('MPWPB_User_Dashboard')) {
          * Enqueue necessary scripts and styles for the dashboard
          */
         public function enqueue_scripts() {
-            wp_enqueue_style('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.css', array(), time());
-            wp_enqueue_script('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.js', array('jquery'), time(), true);
+            wp_enqueue_style('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.css', array(), MPWPB_VERSION);
+            wp_enqueue_script('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.js', array('jquery'), MPWPB_VERSION, true);
             // 'staff' picks the mpwpb_staff_* AJAX action names (Admin/MPWPB_Staff_DashBoard.php)
             // instead of the customer ones below -- both used to register the
             // same action names and silently collided.

--- a/Frontend/MPWPB_Wc_Checkout_Fields_Helper.php
+++ b/Frontend/MPWPB_Wc_Checkout_Fields_Helper.php
@@ -620,7 +620,10 @@
 					// Create proper upload overrides
 					$upload_overrides = array(
 						'test_form' => false,
-						'mimes' => $this->allowed_mime_types
+						'mimes' => $this->allowed_mime_types,
+						'unique_filename_callback' => static function($dir, $name, $ext) {
+							return 'mpwpb-' . wp_generate_password(32, false, false) . $ext;
+						},
 					);
 
 					// Use WordPress's built-in file handling

--- a/MPWPB_Plugin.php
+++ b/MPWPB_Plugin.php
@@ -26,6 +26,9 @@
 				if (!defined('MPWPB_PLUGIN_URL')) {
 					define('MPWPB_PLUGIN_URL', plugins_url() . '/' . plugin_basename(dirname(__FILE__)));
 				}
+				if (!defined('MPWPB_VERSION')) {
+					define('MPWPB_VERSION', '1.3.1');
+				}
 				require_once MPWPB_PLUGIN_DIR . '/mp_global/MPWPB_Global_File_Load.php';
 				add_action('activated_plugin', array($this, 'activation_redirect'), 90, 1);
 				require_once MPWPB_PLUGIN_DIR . '/inc/MPWPB_Dependencies.php';
@@ -50,7 +53,8 @@
 						));
 					}
 					flush_rewrite_rules();
-					exit(esc_url_raw(wp_redirect(admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_list'))));
+					wp_safe_redirect(admin_url('edit.php?post_type=mpwpb_item&page=mpwpb_service_list'));
+					exit;
 				}
 			}
 			public static function plugin_activate() {

--- a/inc/MPWPB_Dependencies.php
+++ b/inc/MPWPB_Dependencies.php
@@ -60,7 +60,7 @@
 			}
 			public function global_enqueue() {
 				do_action('add_mpwpb_common_script');
-				wp_enqueue_style('mage-icon', MPWPB_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), time());
+				wp_enqueue_style('mage-icon', MPWPB_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), MPWPB_VERSION);
 				
                 self::staff_dashboard_enqueue_scripts();
 			}
@@ -71,8 +71,8 @@
 
                     wp_enqueue_script('jquery-ui-sortable');
                     // your script depends on jQuery UI
-                    wp_enqueue_style('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.css', array(), time());
-                    wp_enqueue_script('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.js', array('jquery'), time(), true);
+                    wp_enqueue_style('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.css', array(), MPWPB_VERSION);
+                    wp_enqueue_script('mpwpb-user-dashboard', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_user_dashboard.js', array('jquery'), MPWPB_VERSION, true);
                     wp_localize_script('mpwpb-user-dashboard', 'mpwpb_dashboard', array(
                         'ajaxurl' => admin_url('admin-ajax.php'),
                         'nonce' => wp_create_nonce('mpwpb_dashboard_nonce'),
@@ -84,15 +84,15 @@
 			public function admin_scripts() {
 				$this->global_enqueue();
 				// ****custom************//
-				wp_enqueue_style('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.css', [], time());
-				wp_enqueue_style('admin_style', MPWPB_PLUGIN_URL . '/assets/admin/admin_style.css', [], time());
-                wp_enqueue_style('mpwpb_service_list', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_service_list.css', [], time());
-                wp_enqueue_style('mpwpb_staff_member', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_staff_member.css', [], time());
-                wp_enqueue_style('mpwpb_analytics_dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.css', [], time());
-				wp_enqueue_script('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.js', ['jquery'], time(), true);
+				wp_enqueue_style('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.css', [], MPWPB_VERSION);
+				wp_enqueue_style('admin_style', MPWPB_PLUGIN_URL . '/assets/admin/admin_style.css', [], MPWPB_VERSION);
+                wp_enqueue_style('mpwpb_service_list', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_service_list.css', [], MPWPB_VERSION);
+                wp_enqueue_style('mpwpb_staff_member', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_staff_member.css', [], MPWPB_VERSION);
+                wp_enqueue_style('mpwpb_analytics_dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.css', [], MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.js', ['jquery'], MPWPB_VERSION, true);
 				// Staff Management page reskin — live off-day/schedule-row sync only;
 				// no-ops (returns early) on any other admin screen.
-				wp_enqueue_script('mpwpb_staff_management_modern', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb-staff-management-modern.js', ['jquery'], time(), true);
+				wp_enqueue_script('mpwpb_staff_management_modern', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb-staff-management-modern.js', ['jquery'], MPWPB_VERSION, true);
 				wp_localize_script('mpwpb_staff_management_modern', 'mpwpbStaffScheduleI18n', array(
 					'active' => __('ACTIVE', 'service-booking-manager'),
 					'off'    => __('OFF', 'service-booking-manager'),
@@ -109,33 +109,33 @@
 				$this->global_enqueue();
 				wp_enqueue_script('wc-checkout');
 				// custom
-				wp_enqueue_style('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.css', [], time());
-				wp_enqueue_script('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.js', ['jquery'], time(), true);
-				wp_enqueue_style('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.css', [], time());
-				wp_enqueue_script('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.js', ['jquery'], time());
-				wp_enqueue_style('mpwpb_coupon', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-coupon.css', [], time());
+				wp_enqueue_style('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.css', [], MPWPB_VERSION);
+				wp_enqueue_script('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.js', ['jquery'], MPWPB_VERSION, true);
+				wp_enqueue_style('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.css', [], MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.js', ['jquery'], MPWPB_VERSION);
+				wp_enqueue_style('mpwpb_coupon', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-coupon.css', [], MPWPB_VERSION);
 				// Depends on mpwpb_registration (not just jquery) so the
 				// mpwpb_ajax object it localizes is guaranteed to already exist.
-				wp_enqueue_script('mpwpb_coupon', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-coupon.js', ['jquery', 'mpwpb_registration'], time(), true);
+				wp_enqueue_script('mpwpb_coupon', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-coupon.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// Pay in Full / Pay Deposit Now toggle on the checkout pages
 				// (WC checkout + native checkout) -- same AJAX-then-refresh
 				// pattern as mpwpb_coupon above.
-				wp_enqueue_script('mpwpb_payment_choice', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-payment-choice.js', ['jquery', 'mpwpb_registration'], time(), true);
+				wp_enqueue_script('mpwpb_payment_choice', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-payment-choice.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// Single service page redesign (hero/tabs/Overview/FAQ/Details) —
 				// pure reskin, loaded after mpwpb_registration so its overrides win.
-				wp_enqueue_style('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.css', ['mpwpb_registration'], time());
-				wp_enqueue_script('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.js', ['jquery', 'mpwpb_registration'], time(), true);
+				wp_enqueue_style('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.css', ['mpwpb_registration'], MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// "Our services" sidebar tree expand/collapse only — selecting a
 				// service still goes through mpwpb_registration.js unchanged.
-				wp_enqueue_script('mpwpb_service_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-tree.js', ['jquery', 'mpwpb_registration'], time(), true);
+				wp_enqueue_script('mpwpb_service_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-tree.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// Booking popup's inner picker: relocates the real category/
 				// service elements (untouched click handlers/hidden inputs)
 				// into a unified checkbox-tree — no new selection logic.
-				wp_enqueue_script('mpwpb_booking_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-booking-tree.js', ['jquery', 'mpwpb_registration', 'mpwpb_service_tree'], time(), true);
+				wp_enqueue_script('mpwpb_booking_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-booking-tree.js', ['jquery', 'mpwpb_registration', 'mpwpb_service_tree'], MPWPB_VERSION, true);
 				// WooCommerce My Account > Orders reskin — pure CSS, no
 				// template override or new markup (see the file's own header
 				// comment). Loaded after mpwpb_registration so its overrides win.
-				wp_enqueue_style('mpwpb_account_orders_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-account-orders-modern.css', ['mpwpb_registration'], time());
+				wp_enqueue_style('mpwpb_account_orders_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-account-orders-modern.css', ['mpwpb_registration'], MPWPB_VERSION);
 				wp_localize_script('mpwpb_registration', 'mpwpb_ajax', array(
 					'ajax_url' => admin_url('admin-ajax.php'),
 					'nonce'    => wp_create_nonce('mpwpb_nonce'),

--- a/mp_global/MPWPB_Global_File_Load.php
+++ b/mp_global/MPWPB_Global_File_Load.php
@@ -49,8 +49,8 @@
 				wp_enqueue_script('mp_select_2', MPWPB_GLOBAL_PLUGIN_URL . '/assets/select_2/select2.min.js', array(), '4.0.13',true);
 				wp_enqueue_style('mp_owl_carousel', MPWPB_GLOBAL_PLUGIN_URL . '/assets/owl_carousel/owl.carousel.min.css', array(), '2.3.4');
 				wp_enqueue_script('mp_owl_carousel', MPWPB_GLOBAL_PLUGIN_URL . '/assets/owl_carousel/owl.carousel.min.js', array(), '2.3.4',true);
-				wp_enqueue_style('mpwpb_plugin_global', MPWPB_GLOBAL_PLUGIN_URL . '/assets/mp_style/mpwpb_plugin_global.css', array(), time());
-				wp_enqueue_script('mpwpb_plugin_global', MPWPB_GLOBAL_PLUGIN_URL . '/assets/mp_style/mpwpb_plugin_global.js', array('jquery'), time());
+				wp_enqueue_style('mpwpb_plugin_global', MPWPB_GLOBAL_PLUGIN_URL . '/assets/mp_style/mpwpb_plugin_global.css', array(), MPWPB_VERSION);
+				wp_enqueue_script('mpwpb_plugin_global', MPWPB_GLOBAL_PLUGIN_URL . '/assets/mp_style/mpwpb_plugin_global.js', array('jquery'), MPWPB_VERSION);
 				do_action('add_mpwpb_global_enqueue');
 			}
 			public function admin_enqueue() {
@@ -64,13 +64,13 @@
 				wp_enqueue_style('wp-codemirror');
 				wp_enqueue_script('wp-codemirror');;
 				//loading Time picker
-				wp_enqueue_script('jquery.timepicker.min', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/jquery.timepicker.min.js', array('jquery'), time(), true);
-				wp_enqueue_style('jquery.timepicker.min', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/jquery.timepicker.min.css', array(), time());
+				wp_enqueue_script('jquery.timepicker.min', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/jquery.timepicker.min.js', array('jquery'), MPWPB_VERSION, true);
+				wp_enqueue_style('jquery.timepicker.min', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/jquery.timepicker.min.css', array(), MPWPB_VERSION);
 				//=====================//
 				wp_enqueue_script('form-field-dependency', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/form-field-dependency.js', array('jquery'), '1.0', true);
 				// admin setting global
-				wp_enqueue_script('mpwpb_admin_settings', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/mpwpb_admin_settings.js', array('jquery'), time(), true);
-				wp_enqueue_style('mpwpb_admin_settings', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/mpwpb_admin_settings.css', array(), time());
+				wp_enqueue_script('mpwpb_admin_settings', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/mpwpb_admin_settings.js', array('jquery'), MPWPB_VERSION, true);
+				wp_enqueue_style('mpwpb_admin_settings', MPWPB_GLOBAL_PLUGIN_URL . '/assets/admin/mpwpb_admin_settings.css', array(), MPWPB_VERSION);
 				do_action('add_mpwpb_admin_enqueue');
 			}
 			public function frontend_enqueue() {


### PR DESCRIPTION
Working-tree changes across the free plugin (separate from the reviews/staff/recurring-price work in #184):

- Analytics dashboard
- WooCommerce checkout fields (+ helper)
- Recurring booking — settings + frontend
- AJAX file upload
- GDPR cookie banner
- User dashboard
- Plugin bootstrap, dependency loader, global file loader

🤖 Generated with [Claude Code](https://claude.com/claude-code)