### PR TITLE
Dynamic Time Slot Length + booking duration everywhere

### DIFF
--- a/Admin/MPWPB_Native_Order.php
+++ b/Admin/MPWPB_Native_Order.php
@@ -172,6 +172,10 @@
 					$line_items[] = [
 						'post_id' => $cart_item['mpwpb_id'] ?? 0,
 						'date' => $cart_item['mpwpb_date'] ?? '',
+						// Slot length frozen when the item was added to the cart; 0
+						// on older carts, where the booking builder falls back to the
+						// service's current setting.
+						'slot_length' => (int) ($cart_item['mpwpb_slot_length'] ?? 0),
 						'staff_term_id' => $cart_item['mpwpb_staff_member_id'] ?? '',
 						'category' => $cart_item['mpwpb_category'] ?? '',
 						'sub_category' => $cart_item['mpwpb_sub_category'] ?? '',

--- a/Admin/MPWPB_Settings.php
+++ b/Admin/MPWPB_Settings.php
@@ -110,7 +110,20 @@
 					$active_days = isset($_POST['mpwpb_active_days']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_active_days'])) : '';
 					update_post_meta($post_id, 'mpwpb_active_days', $active_days);
 					//**********************//
+					// "custom" means the admin typed a free length into the companion
+					// number field instead of picking a preset. Stored as plain minutes
+					// either way, so every consumer keeps reading one simple integer.
 					$time_slot_length = isset($_POST['mpwpb_time_slot_length']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_time_slot_length'])) : '';
+					if ($time_slot_length === 'custom') {
+						$time_slot_length = isset($_POST['mpwpb_time_slot_length_custom']) ? absint(wp_unslash($_POST['mpwpb_time_slot_length_custom'])) : 0;
+					} else {
+						$time_slot_length = absint($time_slot_length);
+					}
+					// Never persist 0/blank -- that would make get_time_slot() fall back
+					// to its own default and silently change an existing schedule.
+					if ($time_slot_length < 1) {
+						$time_slot_length = MPWPB_Function::get_slot_length($post_id);
+					}
 					$capacity_per_session = isset($_POST['mpwpb_capacity_per_session']) ? sanitize_text_field(wp_unslash($_POST['mpwpb_capacity_per_session'])) : '';
 					update_post_meta($post_id, 'mpwpb_time_slot_length', $time_slot_length);
 					update_post_meta($post_id, 'mpwpb_capacity_per_session', $capacity_per_session);

--- a/Admin/settings-modern/MPWPB_Date_Time_Modern.php
+++ b/Admin/settings-modern/MPWPB_Date_Time_Modern.php
@@ -123,17 +123,29 @@
 										<input type="text" class="formControl mpwpb_number_validation" name="mpwpb_active_days" value="<?php echo esc_attr($active_days); ?>"/>
 									</div>
 
+									<?php
+										// Presets + free "Custom" value. Any minute value is valid
+										// (get_time_slot()/get_slot_length() clamp only to >= 1), so a
+										// saved length that isn't one of the presets must still show
+										// correctly instead of rendering as an empty select.
+										$slot_presets = MPWPB_Function::slot_length_presets();
+										$slot_is_custom = $time_slot !== '' && !array_key_exists((int) $time_slot, $slot_presets);
+									?>
 									<div class="mpwpb-dtm__field">
 										<label class="mpwpb-dtm__field-label"><?php esc_html_e('Time Slot Length', 'service-booking-manager'); ?> <span class="textRequired">&nbsp;*</span></label>
-										<select class="formControl" name="mpwpb_time_slot_length">
-											<option selected disabled><?php esc_html_e('Select time slot Length', 'service-booking-manager'); ?></option>
-											<option value="10" <?php selected($time_slot, 10); ?>><?php esc_html_e('10 min', 'service-booking-manager'); ?></option>
-											<option value="15" <?php selected($time_slot, 15); ?>><?php esc_html_e('15 min', 'service-booking-manager'); ?></option>
-											<option value="30" <?php selected($time_slot, 30); ?>><?php esc_html_e('30 min', 'service-booking-manager'); ?></option>
-											<option value="60" <?php selected($time_slot, 60); ?>><?php esc_html_e('1 Hour', 'service-booking-manager'); ?></option>
-											<option value="120" <?php selected($time_slot, 120); ?>><?php esc_html_e('2 Hour', 'service-booking-manager'); ?></option>
-											<option value="180" <?php selected($time_slot, 180); ?>><?php esc_html_e('3 Hour', 'service-booking-manager'); ?></option>
+										<select class="formControl mpwpb-slot-length-select" name="mpwpb_time_slot_length">
+											<option value="" <?php selected($time_slot, ''); ?> disabled><?php esc_html_e('Select time slot Length', 'service-booking-manager'); ?></option>
+											<?php foreach ($slot_presets as $preset_value => $preset_label) { ?>
+												<option value="<?php echo esc_attr($preset_value); ?>" <?php selected((int) $time_slot, $preset_value); ?>><?php echo esc_html($preset_label); ?></option>
+											<?php } ?>
+											<option value="custom" <?php selected($slot_is_custom, true); ?>><?php esc_html_e('Custom…', 'service-booking-manager'); ?></option>
 										</select>
+										<div class="mpwpb-dtm__slot-custom" style="<?php echo $slot_is_custom ? '' : 'display:none;'; ?>">
+											<input type="number" class="formControl mpwpb-slot-length-custom" name="mpwpb_time_slot_length_custom" min="1" step="1"
+											       value="<?php echo esc_attr($slot_is_custom ? (int) $time_slot : ''); ?>"
+											       placeholder="<?php esc_attr_e('Ex. 45', 'service-booking-manager'); ?>"/>
+											<small class="mpwpb-dtm__hint"><?php esc_html_e('Length in minutes.', 'service-booking-manager'); ?></small>
+										</div>
 									</div>
 
 									<div class="mpwpb-dtm__field">

--- a/Admin/settings/Date_Time.php
+++ b/Admin/settings/Date_Time.php
@@ -111,15 +111,24 @@
                                         
                                         <p><?php esc_html_e('Time Slot Length', 'service-booking-manager'); ?> <span class="textRequired">&nbsp;*</span></p>
                                         
-                                        <select name="mpwpb_time_slot_length">
-                                            <option selected disabled><?php esc_html_e('Select time slot Length', 'service-booking-manager'); ?></option>
-                                            <option value="10" <?php echo esc_attr($time_slot == 10 ? 'selected' : ''); ?>><?php esc_html_e('10 min', 'service-booking-manager'); ?></option>
-                                            <option value="15" <?php echo esc_attr($time_slot == 15 ? 'selected' : ''); ?>><?php esc_html_e('15 min', 'service-booking-manager'); ?></option>
-                                            <option value="30" <?php echo esc_attr($time_slot == 30 ? 'selected' : ''); ?>><?php esc_html_e('30 min', 'service-booking-manager'); ?></option>
-                                            <option value="60" <?php echo esc_attr($time_slot == 60 ? 'selected' : ''); ?>><?php esc_html_e('1 Hour', 'service-booking-manager'); ?></option>
-                                            <option value="120" <?php echo esc_attr($time_slot == 120 ? 'selected' : ''); ?>><?php esc_html_e('2 Hour', 'service-booking-manager'); ?></option>
-                                            <option value="180" <?php echo esc_attr($time_slot == 180 ? 'selected' : ''); ?>><?php esc_html_e('3 Hour', 'service-booking-manager'); ?></option>
+                                        <?php
+                                            // Presets + free "Custom" value -- any minute length is valid,
+                                            // so a saved non-preset value must still render selected.
+                                            $slot_presets = MPWPB_Function::slot_length_presets();
+                                            $slot_is_custom = $time_slot !== '' && !array_key_exists((int) $time_slot, $slot_presets);
+                                        ?>
+                                        <select class="mpwpb-slot-length-select" name="mpwpb_time_slot_length">
+                                            <option value="" <?php selected($time_slot, ''); ?> disabled><?php esc_html_e('Select time slot Length', 'service-booking-manager'); ?></option>
+                                            <?php foreach ($slot_presets as $preset_value => $preset_label) { ?>
+                                                <option value="<?php echo esc_attr($preset_value); ?>" <?php selected((int) $time_slot, $preset_value); ?>><?php echo esc_html($preset_label); ?></option>
+                                            <?php } ?>
+                                            <option value="custom" <?php selected($slot_is_custom, true); ?>><?php esc_html_e('Custom…', 'service-booking-manager'); ?></option>
                                         </select>
+                                        <span class="mpwpb-dtm__slot-custom" style="<?php echo $slot_is_custom ? '' : 'display:none;'; ?>">
+                                            <input type="number" class="formControl mpwpb-slot-length-custom" name="mpwpb_time_slot_length_custom" min="1" step="1"
+                                                   value="<?php echo esc_attr($slot_is_custom ? (int) $time_slot : ''); ?>"
+                                                   placeholder="<?php esc_attr_e('Ex. 45 (minutes)', 'service-booking-manager'); ?>"/>
+                                        </span>
                                     </label>
                                 </div>
                                 <div>

--- a/Frontend/MPWPB_Details_Layout.php
+++ b/Frontend/MPWPB_Details_Layout.php
@@ -65,6 +65,10 @@
                     <div class="mpwpb_time_display" id="<?php echo esc_attr($start_date);?>" style="display: <?php echo esc_attr( $display );?>" data-date-filder="<?php echo esc_attr( $start_date );?>">
                         <?php
                         $all_time_slots = MPWPB_Function::get_time_slot( $post_id, $start_date );
+                        // data-date feeds the wizard's "Selected Date & Time" summary
+                        // (mpwpb_registration.js) -- carry the slot's end time so the
+                        // customer sees the whole window, not just when it starts.
+                        $slot_minutes = MPWPB_Function::get_slot_length( $post_id );
                         $happy_hours_badge = class_exists('MPWPB_Happy_Hours_Helper') ? MPWPB_Happy_Hours_Helper::get_badge_label( $post_id ) : '';
                         $happy_hours_rule = $happy_hours_badge !== '' ? MPWPB_Happy_Hours_Helper::get_rule( $post_id ) : null;
                         if (sizeof($all_time_slots) > 0) {
@@ -73,7 +77,7 @@
                                 if ($available > 0) {
                                     $is_happy_hour = $happy_hours_rule !== null && MPWPB_Happy_Hours_Helper::time_in_window( $slot, $happy_hours_rule );
                                     ?>
-                                    <button type="button" class=" to-book mpwpb_time_btn<?php echo $is_happy_hour ? ' mpwpb-happy-hour-slot' : ''; ?>" data-date="<?php echo esc_attr(MPWPB_Global_Function::date_format($slot, 'full')); ?>" data-radio-check="<?php echo esc_attr($slot); ?>" data-open-icon="fas fa-check" data-close-icon=""<?php if ( $is_happy_hour ) { ?> data-hh-type="<?php echo esc_attr($happy_hours_rule['discount_type']); ?>" data-hh-value="<?php echo esc_attr($happy_hours_rule['discount_value']); ?>"<?php } ?>>
+                                    <button type="button" class=" to-book mpwpb_time_btn<?php echo $is_happy_hour ? ' mpwpb-happy-hour-slot' : ''; ?>" data-date="<?php echo esc_attr(MPWPB_Global_Function::date_format($slot, 'date') . ' ' . MPWPB_Function::format_slot_time_range($slot, $slot_minutes)); ?>" data-radio-check="<?php echo esc_attr($slot); ?>" data-open-icon="fas fa-check" data-close-icon=""<?php if ( $is_happy_hour ) { ?> data-hh-type="<?php echo esc_attr($happy_hours_rule['discount_type']); ?>" data-hh-value="<?php echo esc_attr($happy_hours_rule['discount_value']); ?>"<?php } ?>>
                                         <!-- <span data-icon></span> --><?php echo esc_html(MPWPB_Global_Function::date_format($slot, 'time')); ?>
                                         <?php if ( $is_happy_hour ) { ?>
                                             <span class="mpwpb-happy-hour-badge"><?php echo esc_html($happy_hours_badge); ?></span>

--- a/Frontend/MPWPB_Native_Checkout.php
+++ b/Frontend/MPWPB_Native_Checkout.php
@@ -187,11 +187,23 @@
 				$time_format = $use_24hour === 'yes' ? 'H:i' : 'g:i A';
 				/* translators: %s: formatted time, e.g. "10:30 AM" */
 				$slot_format = sprintf(__('l, M j \@ %s', 'service-booking-manager'), $time_format);
+				// Show the slot's end time too ("10:00 AM - 11:00 AM") so the
+				// customer can see how long the appointment actually runs. Prefer
+				// the length frozen on the booking; fall back to the service's
+				// current setting for older records that predate it.
+				$slot_minutes = (int) ($item['mpwpb_slot_length'] ?? 0);
+				if ($slot_minutes < 1) {
+					$slot_minutes = MPWPB_Function::get_slot_length($post_id);
+				}
 				$slot_displays = [];
 				foreach ($date_segments as $segment) {
 					$segment_ts = strtotime($segment);
 					if ($segment_ts) {
-						$slot_displays[] = date_i18n($slot_format, $segment_ts);
+						$slot_display = date_i18n($slot_format, $segment_ts);
+						if ($slot_minutes > 0) {
+							$slot_display .= ' - ' . date_i18n($time_format, $segment_ts + ($slot_minutes * MINUTE_IN_SECONDS));
+						}
+						$slot_displays[] = $slot_display;
 					}
 				}
 

--- a/Frontend/MPWPB_Woocommerce.php
+++ b/Frontend/MPWPB_Woocommerce.php
@@ -374,6 +374,10 @@
 						$cart_item_data['mpwpb_sub_category'] = MPWPB_Function::get_sub_category_name($product_id, $sub_category);
 						$cart_item_data['mpwpb_service'] = $all_service;
 						$cart_item_data['mpwpb_date'] = $date;
+						// Frozen at add-to-cart time so the booked slot keeps its
+						// original length even if the service is edited before the
+						// order is completed.
+						$cart_item_data['mpwpb_slot_length'] = MPWPB_Function::get_slot_length($product_id);
 						$cart_item_data['mpwpb_extra_service_info'] = self::cart_extra_service_info($product_id, $date, $ex_service_types, $ex_service_qty);
 						$cart_item_data['mpwpb_tp'] = $total_price;
 						$cart_item_data['line_total'] = $total_price;
@@ -578,10 +582,22 @@
 							$item->add_meta_data(esc_html__('Price ', 'service-booking-manager'), MPWPB_Global_Function::wc_price($post_id, $service['price']));
 						}
 					}
+                    // Slot length is captured at purchase time, not read live from
+                    // the service later -- an admin changing "Time Slot Length"
+                    // afterwards must never rewrite what an existing customer
+                    // already booked. These visible meta rows are what WooCommerce
+                    // then renders everywhere for free: admin order detail, every
+                    // order email, My Account order details, the thank-you page and
+                    // any PDF that prints order item meta.
+                    $slot_length = (int) ($values['mpwpb_slot_length'] ?? 0) ?: MPWPB_Function::get_slot_length($post_id);
+                    $slot_duration_label = MPWPB_Function::format_slot_duration($slot_length);
                     if( is_array($date_array) && sizeof($date_array) > 0 ) {
                         foreach ($date_array as $days) {
                             $item->add_meta_data(esc_html__('Date ', 'service-booking-manager'), esc_html(MPWPB_Global_Function::date_format($days)));
-                            $item->add_meta_data(esc_html__('Time ', 'service-booking-manager'), esc_html(MPWPB_Global_Function::date_format($days, 'time')));
+                            $item->add_meta_data(esc_html__('Time ', 'service-booking-manager'), esc_html(MPWPB_Function::format_slot_time_range($days, $slot_length)));
+                        }
+                        if ($slot_duration_label) {
+                            $item->add_meta_data(esc_html__('Duration ', 'service-booking-manager'), esc_html($slot_duration_label));
                         }
                     }
 					if (sizeof($extra_service) > 0) {
@@ -601,6 +617,10 @@
 					$item->add_meta_data('_mpwpb_id', $post_id);
 					$item->add_meta_data('_mpwpb_staff_term_id', $staff_member);
 					$item->add_meta_data('_mpwpb_date', $date);
+					// Machine-readable copy so order list / PDF / calendar can
+					// recompute the end time without re-reading (possibly changed)
+					// service settings.
+					$item->add_meta_data('_mpwpb_slot_length', $slot_length);
 					if ($category) {
 						$item->add_meta_data('_mpwpb_category', $category);
 						if ($sub_category) {
@@ -650,6 +670,9 @@
 					$line_items[] = [
 						'post_id' => $post_id,
 						'date' => $date ? sanitize_text_field(wp_unslash($date)) : '',
+						// 0 on orders placed before slot length was recorded; the
+						// booking builder falls back to the service setting then.
+						'slot_length' => (int) wc_get_order_item_meta($item_id, '_mpwpb_slot_length'),
 						'staff_term_id' => wc_get_order_item_meta($item_id, '_mpwpb_staff_term_id'),
 						'category' => $category ? sanitize_text_field(wp_unslash($category)) : '',
 						'sub_category' => $sub_category ? sanitize_text_field(wp_unslash($sub_category)) : '',
@@ -786,6 +809,11 @@
 						$data = [];
 						$data['mpwpb_id'] = $post_id;
 						$data['mpwpb_date'] = $occurrence_date;
+						// Frozen per booking so the recorded end time stays correct
+						// even if the service's slot length is edited later. Prefer
+						// what the order item stored at purchase time; only fall back
+						// to the service's current setting for older orders.
+						$data['mpwpb_slot_length'] = (int) ($line_item['slot_length'] ?? 0) ?: MPWPB_Function::get_slot_length($post_id);
 						if ($occurrence_count > 1) {
 							$data['mpwpb_recurring_index'] = $occurrence_index + 1;
 							$data['mpwpb_recurring_total'] = $occurrence_count;

--- a/assets/admin/mpwpb_admin.js
+++ b/assets/admin/mpwpb_admin.js
@@ -1873,4 +1873,22 @@
         alert('Copied!');
     });
 
+    //==========Time Slot Length: presets + custom value=================//
+    // Shared by both the modern and the classic service editor (same markup
+    // classes). Picking "Custom…" reveals a minutes input; the save handler
+    // (MPWPB_Settings) resolves "custom" to that number, so only one plain
+    // integer is ever stored in mpwpb_time_slot_length.
+    $(document).on('change', '.mpwpb-slot-length-select', function () {
+        var $select = $(this);
+        var $custom = $select.closest('.mpwpb-dtm__field, label, div').find('.mpwpb-dtm__slot-custom').first();
+        if (!$custom.length) { return; }
+        var isCustom = $select.val() === 'custom';
+        $custom.toggle(isCustom);
+        var $input = $custom.find('.mpwpb-slot-length-custom');
+        // Only required while it is the live value, otherwise an empty hidden
+        // field would block the form from submitting.
+        $input.prop('required', isCustom);
+        if (isCustom) { $input.trigger('focus'); }
+    });
+
 })(jQuery);

--- a/inc/MPWPB_Function.php
+++ b/inc/MPWPB_Function.php
@@ -282,11 +282,98 @@
 				}
 				return apply_filters('mpwpb_get_date', $all_dates, $post_id);
 			}
+			/**
+			 * Quick-pick slot lengths (minutes => label) offered in the editor.
+			 * Purely a convenience list -- admins can enter any custom length,
+			 * so nothing downstream may treat these as the allowed set.
+			 */
+			public static function slot_length_presets(): array {
+				return apply_filters('mpwpb_slot_length_presets', array(
+					10 => __('10 min', 'service-booking-manager'),
+					15 => __('15 min', 'service-booking-manager'),
+					30 => __('30 min', 'service-booking-manager'),
+					45 => __('45 min', 'service-booking-manager'),
+					60 => __('1 Hour', 'service-booking-manager'),
+					90 => __('1h 30m', 'service-booking-manager'),
+					120 => __('2 Hours', 'service-booking-manager'),
+					180 => __('3 Hours', 'service-booking-manager'),
+				));
+			}
+
+			/**
+			 * Booking slot length (in minutes) configured for a service.
+			 *
+			 * The editor offers presets plus a free "Custom" value, so this can be
+			 * any positive number of minutes -- never assume one of the old fixed
+			 * options. Clamped to >= 1 so slot maths can never step by zero.
+			 */
+			public static function get_slot_length($post_id, $fallback = 30) {
+				return max(1, (int) MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_time_slot_length', $fallback));
+			}
+
+			/**
+			 * Slot length recorded ON a booking, falling back to the service's
+			 * current setting for bookings created before the length was stored
+			 * per booking (so existing orders still render a duration).
+			 */
+			public static function get_booking_slot_length($booking_id, $post_id = 0) {
+				$stored = (int) get_post_meta($booking_id, 'mpwpb_slot_length', true);
+				if ($stored > 0) {
+					return $stored;
+				}
+				$post_id = $post_id ?: (int) get_post_meta($booking_id, 'mpwpb_id', true);
+				return $post_id ? self::get_slot_length($post_id) : 0;
+			}
+
+			/**
+			 * Human label for a slot length -- "45 min", "1 Hour", "2 Hours", "1h 30m".
+			 */
+			public static function format_slot_duration($minutes) {
+				$minutes = (int) $minutes;
+				if ($minutes < 1) {
+					return '';
+				}
+				$hours = intdiv($minutes, 60);
+				$mins = $minutes % 60;
+				if ($hours > 0 && $mins > 0) {
+					/* translators: 1: whole hours, 2: leftover minutes */
+					return sprintf(__('%1$dh %2$dm', 'service-booking-manager'), $hours, $mins);
+				}
+				if ($hours > 0) {
+					return $hours === 1
+						? __('1 Hour', 'service-booking-manager')
+						/* translators: %d: number of hours */
+						: sprintf(__('%d Hours', 'service-booking-manager'), $hours);
+				}
+				/* translators: %d: number of minutes */
+				return sprintf(__('%d min', 'service-booking-manager'), $mins);
+			}
+
+			/**
+			 * "10:00 am - 11:00 am" for a slot, using the site's configured time
+			 * format (including the plugin's 24-hour option). Falls back to just
+			 * the start time when no usable length is known, so callers can use
+			 * this unconditionally.
+			 */
+			public static function format_slot_time_range($start, $minutes) {
+				$timestamp = $start ? strtotime($start) : false;
+				if (!$timestamp) {
+					return '';
+				}
+				$start_label = MPWPB_Global_Function::date_format($start, 'time');
+				$minutes = (int) $minutes;
+				if ($minutes < 1) {
+					return $start_label;
+				}
+				$end = date_i18n('Y-m-d H:i', $timestamp + ($minutes * MINUTE_IN_SECONDS));
+				return $start_label . ' - ' . MPWPB_Global_Function::date_format($end, 'time');
+			}
+
 			public static function get_time_slot($post_id, $start_date) {
 				$now_full = current_time( 'Y-m-d H:i' );
 
 				$all_slots = [];
-				$slot_length = max(1, (int) MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_time_slot_length', 30)) * 60;
+				$slot_length = self::get_slot_length($post_id) * 60;
 				// Get English day name regardless of locale
 				$day_num = date('w', strtotime($start_date)); // 0=Sunday, 1=Monday, etc.
 				$english_days = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];


### PR DESCRIPTION
Time Slot Length was a hardcoded 6-option dropdown (10/15/30/60/120/180) in both editors, even though the save handler and get_time_slot() already accepted any value. It now offers presets plus a free "Custom" minutes input, so any slot length works end to end.

Bookings also carry their slot length, so the booked window (not just its start time) is visible everywhere:

- MPWPB_Function: slot_length_presets(), get_slot_length(), get_booking_slot_length(), format_slot_duration(), format_slot_time_range().
- Editors: presets + "Custom…" with a minutes field (modern and classic); a saved non-preset value now renders correctly instead of a blank select.
- Save handler resolves "custom" to the typed minutes and never persists 0/blank, which would have silently reset an existing schedule.
- Slot length is frozen at add-to-cart/checkout on the cart item, the WC order item (_mpwpb_slot_length) and the booking record (mpwpb_slot_length), so editing a service later cannot rewrite what a customer already booked.
- Order item now shows a Time range plus a Duration row, which WooCommerce renders for free in the admin order, every order email, My Account and the thank-you page.
- Native checkout/thank-you recap and the frontend wizard summary show the slot's end time.

Existing orders have no recorded length and fall back to the service's current setting, so they still render a duration.