### PR TITLE
Fix intermittent "Custom" slot-length input not appearing

### DIFF
--- a/Frontend/MPWPB_Static_Template.php
+++ b/Frontend/MPWPB_Static_Template.php
@@ -240,7 +240,7 @@
                     </div>
 					<?php endif; ?>
                     <div class="mpwpb-overview-stat">
-                        <p class="mpwpb-overview-stat-num"><?php echo esc_html($time_slot_length > 0 ? $time_slot_length . ' ' . __('min', 'service-booking-manager') : '—'); ?></p>
+                        <p class="mpwpb-overview-stat-num"><?php echo esc_html($time_slot_length > 0 ? MPWPB_Function::format_slot_duration($time_slot_length) : '—'); ?></p>
                         <p class="mpwpb-overview-stat-label"><?php esc_html_e('Typical slot length', 'service-booking-manager'); ?></p>
                     </div>
                     <div class="mpwpb-overview-stat">

--- a/assets/admin/mpwpb-datetime-modern.css
+++ b/assets/admin/mpwpb-datetime-modern.css
@@ -47,6 +47,13 @@
 
 .mpwpb-dtm__hint{margin:0 0 12px;font-size:12px;color:var(--muted,#94a3b8);}
 
+/* Time Slot Length -> "Custom…" reveals a free minutes input, toggled in
+   mpwpb_admin.js. Deliberately no display rule here: visibility is owned by
+   the inline style JS sets, and a class-level display would fight it. */
+.mpwpb-dtm__slot-custom{margin-top:8px;}
+.mpwpb-dtm__slot-custom .mpwpb-slot-length-custom{width:100%;}
+.mpwpb-dtm__slot-custom .mpwpb-dtm__hint{margin:6px 0 0;}
+
 /* -------------------------------------------------------------------- *
  *  Weekly off-day pills — reuses .groupCheckBox/.customCheckboxLabel so
  *  the shared click handler (mpwpb_plugin_global.js) keeps recomputing

--- a/assets/admin/mpwpb_admin.js
+++ b/assets/admin/mpwpb_admin.js
@@ -1878,17 +1878,45 @@
     // classes). Picking "Custom…" reveals a minutes input; the save handler
     // (MPWPB_Settings) resolves "custom" to that number, so only one plain
     // integer is ever stored in mpwpb_time_slot_length.
-    $(document).on('change', '.mpwpb-slot-length-select', function () {
-        var $select = $(this);
-        var $custom = $select.closest('.mpwpb-dtm__field, label, div').find('.mpwpb-dtm__slot-custom').first();
-        if (!$custom.length) { return; }
+    function mpwpbSlotCustomWrap($select) {
+        // The wrapper is always a SIBLING of the select -- a <div> inside
+        // .mpwpb-dtm__field (modern) or a <span> inside the <label> (classic).
+        // Preferring the sibling avoids depending on the surrounding container,
+        // which differs between the two editors.
+        var $wrap = $select.siblings('.mpwpb-dtm__slot-custom').first();
+        if (!$wrap.length) {
+            $wrap = $select.closest('.mpwpb-dtm__field, label, td, div').find('.mpwpb-dtm__slot-custom').first();
+        }
+        return $wrap;
+    }
+
+    function mpwpbSyncSlotCustom($select) {
+        var $wrap = mpwpbSlotCustomWrap($select);
+        if (!$wrap.length) { return; }
         var isCustom = $select.val() === 'custom';
-        $custom.toggle(isCustom);
-        var $input = $custom.find('.mpwpb-slot-length-custom');
+        // Explicit show()/hide() rather than toggle(), so the rendered state is
+        // always derived from the current value instead of whatever inline
+        // style the markup happened to be rendered with.
+        if (isCustom) { $wrap.show(); } else { $wrap.hide(); }
         // Only required while it is the live value, otherwise an empty hidden
         // field would block the form from submitting.
-        $input.prop('required', isCustom);
-        if (isCustom) { $input.trigger('focus'); }
+        $wrap.find('.mpwpb-slot-length-custom').prop('required', isCustom);
+    }
+
+    $(document).on('change', '.mpwpb-slot-length-select', function () {
+        var $select = $(this);
+        mpwpbSyncSlotCustom($select);
+        if ($select.val() === 'custom') {
+            mpwpbSlotCustomWrap($select).find('.mpwpb-slot-length-custom').trigger('focus');
+        }
+    });
+
+    // Reconcile on load so the visible state always matches the selected value
+    // even if the markup was rendered/injected with a stale inline style.
+    $(function () {
+        $('.mpwpb-slot-length-select').each(function () {
+            mpwpbSyncSlotCustom($(this));
+        });
     });
 
 })(jQuery);

--- a/inc/MPWPB_Dependencies.php
+++ b/inc/MPWPB_Dependencies.php
@@ -99,7 +99,13 @@
                 wp_enqueue_style('mpwpb_service_list', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_service_list.css', [], MPWPB_VERSION);
                 wp_enqueue_style('mpwpb_staff_member', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_staff_member.css', [], MPWPB_VERSION);
                 wp_enqueue_style('mpwpb_analytics_dashboard', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_analytics_dashboard.css', [], MPWPB_VERSION);
-				wp_enqueue_script('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.js', ['jquery'], MPWPB_VERSION, true);
+				// Versioned by file mtime, not MPWPB_VERSION: this file changes between
+				// releases, and with a static version browsers kept serving a stale copy,
+				// so newly added admin behaviour (e.g. the Time Slot Length "Custom"
+				// toggle) appeared to work only in some browsers/sessions.
+				$mpwpb_admin_js = MPWPB_PLUGIN_DIR . '/assets/admin/mpwpb_admin.js';
+				$mpwpb_admin_js_ver = file_exists($mpwpb_admin_js) ? (string) filemtime($mpwpb_admin_js) : MPWPB_VERSION;
+				wp_enqueue_script('mpwpb_admin', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb_admin.js', ['jquery'], $mpwpb_admin_js_ver, true);
 				// Staff Management page reskin — live off-day/schedule-row sync only;
 				// no-ops (returns early) on any other admin screen.
 				wp_enqueue_script('mpwpb_staff_management_modern', MPWPB_PLUGIN_URL . '/assets/admin/mpwpb-staff-management-modern.js', ['jquery'], MPWPB_VERSION, true);

--- a/inc/MPWPB_Function.php
+++ b/inc/MPWPB_Function.php
@@ -350,6 +350,52 @@
 			}
 
 			/**
+			 * Best-effort parse of a free-text duration into whole minutes.
+			 * Understands "45", "30m", "30 min", "2h", "2 hours", "1h 30m".
+			 * Returns 0 when nothing recognisable is found.
+			 */
+			public static function parse_duration_to_minutes($duration) {
+				$duration = strtolower(trim((string) $duration));
+				if ($duration === '') {
+					return 0;
+				}
+				$minutes = 0;
+				$matched = false;
+				if (preg_match('/(\d+(?:\.\d+)?)\s*(?:h|hr|hrs|hour|hours)\b/', $duration, $m)) {
+					$minutes += (float) $m[1] * 60;
+					$matched = true;
+				}
+				if (preg_match('/(\d+(?:\.\d+)?)\s*(?:m|min|mins|minute|minutes)\b/', $duration, $m)) {
+					$minutes += (float) $m[1];
+					$matched = true;
+				}
+				// A bare number is taken as minutes ("45").
+				if (!$matched && preg_match('/^(\d+(?:\.\d+)?)$/', $duration, $m)) {
+					$minutes = (float) $m[1];
+					$matched = true;
+				}
+				return $matched ? (int) round($minutes) : 0;
+			}
+
+			/**
+			 * Display label for an admin-entered service duration.
+			 *
+			 * That field is free text, so values are normalised to minutes and
+			 * re-rendered through format_slot_duration() -- "240m" reads as
+			 * "4 Hours" instead of "240m". Anything not recognisable as a
+			 * duration (e.g. "Half day") is returned untouched so custom wording
+			 * is never mangled.
+			 */
+			public static function format_duration_text($duration) {
+				$duration = trim((string) $duration);
+				if ($duration === '') {
+					return '';
+				}
+				$minutes = self::parse_duration_to_minutes($duration);
+				return $minutes > 0 ? self::format_slot_duration($minutes) : $duration;
+			}
+
+			/**
 			 * "10:00 am - 11:00 am" for a slot, using the site's configured time
 			 * format (including the plugin's 24-hour option). Falls back to just
 			 * the start time when no usable length is known, so callers can use

--- a/templates/registration/category_selection.php
+++ b/templates/registration/category_selection.php
@@ -129,7 +129,7 @@
                                             <?php if ($service_duration) { ?>
                                                 <h6 class="textTheme alignCenter">
                                                     <span class="fas fa-clock mR_xs"></span>
-                                                    <span><?php echo wp_kses_post($service_duration); ?></span>
+                                                    <span><?php echo wp_kses_post(MPWPB_Function::format_duration_text($service_duration)); ?></span>
                                                 </h6>
                                             <?php } ?>
                                             <h6 class="_textTheme_min_100"><?php echo wp_kses_post($service_wc_price); ?></h6>

--- a/templates/registration/category_selection_static.php
+++ b/templates/registration/category_selection_static.php
@@ -62,7 +62,7 @@
 	            <span class="mpwpb-tree-checkbox" data-tree-checkbox></span>
 	            <span class="mpwpb-tree-service-main">
 	                <span class="mpwpb-tree-service-name"><?php echo esc_html($service_name); ?></span>
-					<?php if ($duration) { ?><span class="mpwpb-tree-duration"><i class="fas fa-clock"></i> <?php echo wp_kses_post($duration); ?></span><?php } ?>
+					<?php if ($duration) { ?><span class="mpwpb-tree-duration"><i class="fas fa-clock"></i> <?php echo wp_kses_post(MPWPB_Function::format_duration_text($duration)); ?></span><?php } ?>
 	            </span>
 	            <span class="mpwpb-tree-service-side">
 	                <span class="mpwpb-tree-price"><?php echo wp_kses_post($wc_price); ?></span>

--- a/templates/registration/service_selection.php
+++ b/templates/registration/service_selection.php
@@ -58,7 +58,7 @@
 										<?php if ($service_duration) { ?>
                                             <h6 class="textTheme alignCenter mpwpb_service_duration">
                                                 <span class="far fa-clock mR_xs"></span>
-                                                <span><?php echo wp_kses_post($service_duration); ?></span>
+                                                <span><?php echo wp_kses_post(MPWPB_Function::format_duration_text($service_duration)); ?></span>
                                             </h6>
 										<?php } ?>
                                         <h6 class="_textTheme_min_100"><?php echo wp_kses_post($service_wc_price); ?></h6>


### PR DESCRIPTION
The Custom… minutes field showed only sometimes. Two causes:

1. mpwpb_admin.js (which owns the toggle) was enqueued with the static MPWPB_VERSION, so browsers holding a cached copy never received the new handler and clicking "Custom…" did nothing. It only ever looked like it worked when the saved value was already custom, because PHP renders the field visible in that case. Now versioned by file mtime, matching how the modern editor versions its own assets.

2. The handler located the wrapper via closest('.mpwpb-dtm__field, label, div'), which depended on the surrounding container differing between the modern and classic editors. It now resolves the wrapper as a sibling of the select (true in both editors) and only falls back to a container search.

Also: derive visibility from the selected value with explicit show()/hide() instead of toggle(), and reconcile once on load, so the rendered state can never disagree with the selected option. Adds minimal styling for the revealed input.