### PR TITLE
Fix booking notifications, blank-page symptoms and the long date picker

### DIFF
--- a/Admin/MPWPB_CPT.php
+++ b/Admin/MPWPB_CPT.php
@@ -76,7 +76,13 @@
 					'public' 		=> true,
 					'labels' 		=> $labels,
 					'menu_icon' 	=> $icon,
-					'supports' 		=> ['title', 'editor', 'thumbnail'],
+					// 'excerpt' is what the static template's hero subtext under the
+					// service title is meant to come from. Without it registered there
+					// was no Excerpt field anywhere on the service edit screen, so
+					// get_the_excerpt() silently auto-generated the subtext by trimming
+					// the page content (ending in "[...]") -- text the admin could see
+					// on the front end but could not find, edit or remove anywhere.
+					'supports' 		=> ['title', 'editor', 'thumbnail', 'excerpt'],
 					'show_in_rest' 	=> true,
 					'capability_type' => 'post',
 					'publicly_queryable' => true,  // you should be able to query it

--- a/Admin/MPWPB_Native_Checkout_Settings.php
+++ b/Admin/MPWPB_Native_Checkout_Settings.php
@@ -573,6 +573,17 @@
 								</div>
 								<div class="mpwpb-settings-row mpwpb-settings-row-top">
 									<div>
+										<strong><?php esc_html_e('Disable WooCommerce Customer Emails', 'service-booking-manager'); ?></strong>
+										<p class="description"><?php esc_html_e('Bookings are sold through a hidden WooCommerce product, so WooCommerce mails customers its standard "order processing / order complete" notifications, which read like shipping confirmations. Turn this on to stop those automatic emails for orders that only contain bookings — the booking confirmation email with the PDF ticket (Settings → Email) is sent instead. Admin "New order" notifications, manually sent invoices and customer notes are never affected.', 'service-booking-manager'); ?></p>
+									</div>
+									<label>
+										<input type="hidden" name="<?php echo esc_attr($option); ?>[wc_disable_customer_emails]" value="off"/>
+										<input type="checkbox" name="<?php echo esc_attr($option); ?>[wc_disable_customer_emails]" value="on" <?php checked(MPWPB_Global_Function::get_payment_setting('wc_disable_customer_emails', 'off'), 'on'); ?>/>
+										<?php esc_html_e('Do not send WooCommerce order emails to booking customers.', 'service-booking-manager'); ?>
+									</label>
+								</div>
+								<div class="mpwpb-settings-row mpwpb-settings-row-top">
+									<div>
 										<strong><?php esc_html_e('Confirm Booking Based on Payment Status', 'service-booking-manager'); ?></strong>
 										<p class="description"><?php esc_html_e('Select the order statuses that will trigger booking confirmation.', 'service-booking-manager'); ?></p>
 									</div>

--- a/Admin/MPWPB_Settings_Global.php
+++ b/Admin/MPWPB_Settings_Global.php
@@ -269,6 +269,17 @@
 							)
 						),
 						array(
+							'name' => 'date_picker_layout',
+							'label' => esc_html__('Date Picker Layout', 'service-booking-manager'),
+							'desc' => esc_html__('How the booking form shows available dates. "Slider" keeps the row of day cards, paged a few at a time. "Full Calendar" shows a real month grid with the month name and year, one month per page -- far easier once the booking window is long (30, 60, 90 days).', 'service-booking-manager'),
+							'type' => 'select',
+							'default' => 'slider',
+							'options' => array(
+								'slider' => esc_html__('Slider (day cards)', 'service-booking-manager'),
+								'calendar' => esc_html__('Full Calendar (month grid)', 'service-booking-manager'),
+							)
+						),
+						array(
 							'name' => 'date_format',
 							'label' => esc_html__('Date Picker Format', 'service-booking-manager'),
 							'desc' => esc_html__('If you want to change Date Picker Format, please select format. Default  is D d M , yy.', 'service-booking-manager'),

--- a/Frontend/MPWPB_Details_Layout.php
+++ b/Frontend/MPWPB_Details_Layout.php
@@ -98,69 +98,178 @@
                     <?php
                 }
             }
+            /**
+             * Renders the date picker.
+             *
+             * Two layouts, chosen by the "Date Picker Layout" global setting:
+             *
+             *  - 'slider'   (default, unchanged): one card per calendar day in
+             *               a single flow, paged 8 at a time by the prev/next
+             *               arrows. Fine for a short booking window, painful
+             *               once the window is long -- a 90-day window is 12
+             *               pages of clicking to reach the far end.
+             *  - 'calendar': the same day cards laid out as real month grids,
+             *               one month visible at a time with its name and year
+             *               in a header and the prev/next arrows stepping whole
+             *               months. Also fixes the month only ever being
+             *               readable on closed days, since open days showed the
+             *               weekday and day-of-month but never the month.
+             *
+             * Both layouts emit identical day-cell markup, so the click
+             * handling, selected state and disabled states in
+             * mpwpb_registration.js are shared and unchanged.
+             */
             public static function display_booking_date( $post_id, $all_dates, $active_date = null ){
 				if ( empty( $all_dates ) ) {
 					echo '<p class="mpwpb-no-booking-dates">' . esc_html__('No booking dates are currently available.', 'service-booking-manager') . '</p>';
 					return;
 				}
+                $active_date = $active_date ?? self::get_default_active_date( $post_id, $all_dates );
+                if ( self::get_date_picker_layout() === 'calendar' ) {
+                    self::render_date_calendar( $post_id, $all_dates, $active_date );
+                    return;
+                }
                 $start_date = $all_dates[0];
                 $end_date = end($all_dates);
-                $active_date = $active_date ?? self::get_default_active_date( $post_id, $all_dates );
+                while (strtotime($start_date) <= strtotime($end_date)) {
+                    self::render_date_cell( $post_id, $all_dates, $start_date, $active_date );
+                    $start_date = date_i18n('Y-m-d', strtotime($start_date . ' +1 day'));
+                }
+            }
 
+            /**
+             * 'slider' (default -- the historical layout) or 'calendar'.
+             */
+            public static function get_date_picker_layout() {
+                $layout = MPWPB_Global_Function::get_settings( 'mpwpb_global_settings', 'date_picker_layout', 'slider' );
+                return $layout === 'calendar' ? 'calendar' : 'slider';
+            }
+
+            /**
+             * One day of the picker. Shared by both layouts so a day looks and
+             * behaves the same either way:
+             *
+             *  - closed  (not in $all_dates -- an off day or off date),
+             *  - passed  (open, but every slot is behind "now" or fully booked),
+             *  - bookable (clickable; carries data-find-time, which is what
+             *    mpwpb_registration.js binds the time-panel switch to).
+             */
+            private static function render_date_cell( $post_id, $all_dates, $start_date, $active_date ) {
                 $today = date_i18n('Y-m-d');
                 $tomorrow = date_i18n('Y-m-d', strtotime('+1 day'));
+                $selected = $start_date === $active_date ? 'mpwpb_get_date_selected' : '';
+                // "Today"/"Tomorrow" read clearer than the full date +
+                // weekday name in a compact card -- falls back to the
+                // short weekday (Wed, Thu...) beyond that, with the
+                // day-of-month as the big number.
+                if ( $start_date === $today ) {
+                    $day_label = esc_html__('Today', 'service-booking-manager');
+                } elseif ( $start_date === $tomorrow ) {
+                    $day_label = esc_html__('Tomorrow', 'service-booking-manager');
+                } else {
+                    $day_label = date_i18n('D', strtotime($start_date));
+                }
+                $day_number = date_i18n('j', strtotime($start_date));
+                // The full date is always one hover/screen-reader away, in both
+                // layouts -- the compact card itself has no room for the month.
+                $full_date = MPWPB_Global_Function::date_format($start_date);
+                ?>
+                <div class="fdColumn mpwpb_date_time_line" data-date="<?php echo esc_attr( $start_date ); ?>">
+                    <?php if (!in_array($start_date, $all_dates)) { ?>
+                        <div class="_mpBtn_mpDisabled_fullHeight_bgLight mpwpb_get_close_date" title="<?php echo esc_attr( $full_date ); ?>">
+                            <span class="mptrs_day_with_date"><?php echo esc_html( $day_label ); ?></span>
+                            <strong class="mpwpb-date-number"><?php echo esc_html( $day_number ); ?></strong>
+                            <span class="mpwpb_close_date"><?php esc_html_e('Closed', 'service-booking-manager'); ?></span>
+                        </div>
+					<?php } elseif ( ! self::has_available_slots( $post_id, $start_date ) && ! self::has_waiting_list_slots( $post_id, $start_date ) ) {
+                        // An open day (it's in $all_dates), but every one
+                        // of its slots is already gone -- either passed
+                        // (typically today, once its cutoff time is
+                        // behind "now") or fully booked. Shown (not
+                        // silently dropped from the calendar) but
+                        // disabled instead of clickable, no
+                        // "mpwpb_get_date"/data-find-time so the click
+                        // handler in mpwpb_registration.js never binds
+                        // to it and it can't end up selected.
+                        ?>
+                        <div class="_mpBtn_mpDisabled_fullHeight_bgLight mpwpb_get_date_passed" title="<?php echo esc_attr( $full_date ); ?>">
+                            <span class="mptrs_day_with_date"><?php echo esc_html( $day_label ); ?></span>
+                            <strong class="mpwpb-date-number"><?php echo esc_html( $day_number ); ?></strong>
+                            <span class="mpwpb_date_passed_label"><?php esc_html_e('Passed', 'service-booking-manager'); ?></span>
+                        </div>
+                    <?php } else { ?>
+                        <div class="<?php echo esc_attr( $selected );?> mpwpb_get_date" data-find-time="<?php echo esc_attr( $start_date );?>" title="<?php echo esc_attr( $full_date ); ?>">
+                            <span class="mptrs_day_with_date"><?php echo esc_html( $day_label ); ?></span>
+                            <strong class="mpwpb-date-number"><?php echo esc_html( $day_number ); ?></strong>
+                        </div>
+                    <?php } ?>
+                </div>
+                <?php
+            }
 
-                while (strtotime($start_date) <= strtotime($end_date)) {
-                    if( $start_date === $active_date ){
-                        $selected = 'mpwpb_get_date_selected';
-                    }else{
-                        $selected = '';
-                    }
-                    // "Today"/"Tomorrow" read clearer than the full date +
-                    // weekday name in a compact card -- falls back to the
-                    // short weekday (Wed, Thu...) beyond that, with the
-                    // day-of-month as the big number.
-                    if ( $start_date === $today ) {
-                        $day_label = esc_html__('Today', 'service-booking-manager');
-                    } elseif ( $start_date === $tomorrow ) {
-                        $day_label = esc_html__('Tomorrow', 'service-booking-manager');
-                    } else {
-                        $day_label = date_i18n('D', strtotime($start_date));
-                    }
-                    $day_number = date_i18n('j', strtotime($start_date));
+            /**
+             * Month-grid layout: one .mpwpb-date-calendar-month block per month
+             * touched by the booking window, each a real 7-column calendar with
+             * leading blanks so every day sits under its weekday column. Weeks
+             * start on the day configured in Settings > General (start_of_week),
+             * so the grid matches the rest of the site.
+             *
+             * All months are rendered server-side and paged client-side
+             * (initDateCalendarPagination() in mpwpb-booking-tree.js) -- no
+             * extra AJAX round trip per month, and the whole window stays in
+             * the DOM for the existing selection logic to work against.
+             */
+            private static function render_date_calendar( $post_id, $all_dates, $active_date ) {
+                $range_start = $all_dates[0];
+                $range_end   = end( $all_dates );
+                $start_of_week = (int) get_option( 'start_of_week', 1 );
+                $weekday_labels = array();
+                for ( $i = 0; $i < 7; $i ++ ) {
+                    // 1970-01-04 was a Sunday, so this walks Sunday..Saturday
+                    // from whichever weekday the site starts its weeks on.
+                    $weekday_labels[] = date_i18n( 'D', strtotime( '1970-01-04 +' . ( ( $start_of_week + $i ) % 7 ) . ' day' ) );
+                }
+                // date() not date_i18n() for anything that is then compared or
+                // cast: date_i18n() localises digits in some locales, which turns
+                // arithmetic on "t"/"w" into garbage. date_i18n() is used below
+                // only where the value is printed for a human to read.
+                $month_cursor = date( 'Y-m-01', strtotime( $range_start ) );
+                $last_month   = date( 'Y-m-01', strtotime( $range_end ) );
+                while ( strtotime( $month_cursor ) <= strtotime( $last_month ) ) {
+                    $month_ts    = strtotime( $month_cursor );
+                    $days_in_month = (int) date( 't', $month_ts );
+                    $lead_blanks = ( (int) date( 'w', $month_ts ) - $start_of_week + 7 ) % 7;
                     ?>
-                    <div class="fdColumn mpwpb_date_time_line">
-
-                        <?php if (!in_array($start_date, $all_dates)) {
+                    <div class="mpwpb-date-calendar-month" data-month="<?php echo esc_attr( date( 'Y-m', $month_ts ) ); ?>">
+                        <div class="mpwpb-date-month-label"><?php echo esc_html( date_i18n( 'F Y', $month_ts ) ); ?></div>
+                        <div class="mpwpb-date-weekday-row">
+                            <?php foreach ( $weekday_labels as $weekday_label ) { ?>
+                                <span><?php echo esc_html( $weekday_label ); ?></span>
+                            <?php } ?>
+                        </div>
+                        <div class="mpwpb-date-month-days">
+                            <?php
+                                for ( $i = 0; $i < $lead_blanks; $i ++ ) {
+                                    echo '<div class="mpwpb-date-blank" aria-hidden="true"></div>';
+                                }
+                                for ( $day = 1; $day <= $days_in_month; $day ++ ) {
+                                    $date = date( 'Y-m-d', strtotime( date( 'Y-m', $month_ts ) . '-' . $day ) );
+                                    // Days of this month that fall outside the
+                                    // booking window are placeholders, not
+                                    // "closed" days -- the service simply isn't
+                                    // open for booking that far out (or that far
+                                    // back), which is a different thing to say.
+                                    if ( strtotime( $date ) < strtotime( $range_start ) || strtotime( $date ) > strtotime( $range_end ) ) {
+                                        echo '<div class="mpwpb-date-blank mpwpb-date-out-of-range" aria-hidden="true"><span>' . esc_html( $day ) . '</span></div>';
+                                        continue;
+                                    }
+                                    self::render_date_cell( $post_id, $all_dates, $date, $active_date );
+                                }
                             ?>
-                            <div class="_mpBtn_mpDisabled_fullHeight_bgLight mpwpb_get_close_date">
-                                <div class="mpwpb_close_date"><?php echo esc_html(MPWPB_Global_Function::date_format($start_date)); ?></div>
-                            </div>
-						<?php } elseif ( ! self::has_available_slots( $post_id, $start_date ) && ! self::has_waiting_list_slots( $post_id, $start_date ) ) {
-                            // An open day (it's in $all_dates), but every one
-                            // of its slots is already gone -- either passed
-                            // (typically today, once its cutoff time is
-                            // behind "now") or fully booked. Shown (not
-                            // silently dropped from the calendar) but
-                            // disabled instead of clickable, no
-                            // "mpwpb_get_date"/data-find-time so the click
-                            // handler in mpwpb_registration.js never binds
-                            // to it and it can't end up selected.
-                            ?>
-                            <div class="_mpBtn_mpDisabled_fullHeight_bgLight mpwpb_get_date_passed">
-                                <span class="mptrs_day_with_date"><?php echo esc_html( $day_label ); ?></span>
-                                <strong class="mpwpb-date-number"><?php echo esc_html( $day_number ); ?></strong>
-                                <span class="mpwpb_date_passed_label"><?php esc_html_e('Passed', 'service-booking-manager'); ?></span>
-                            </div>
-                        <?php } else { ?>
-                            <div class="<?php echo esc_attr( $selected );?> mpwpb_get_date" data-find-time="<?php echo esc_attr( $start_date );?>">
-                                <span class="mptrs_day_with_date"><?php echo esc_html( $day_label ); ?></span>
-                                <strong class="mpwpb-date-number"><?php echo esc_html( $day_number ); ?></strong>
-                            </div>
-                        <?php } ?>
+                        </div>
                     </div>
                     <?php
-                    $start_date = date_i18n('Y-m-d', strtotime($start_date . ' +1 day'));
+                    $month_cursor = date( 'Y-m-01', strtotime( $month_cursor . ' +1 month' ) );
                 }
             }
 		}

--- a/Frontend/MPWPB_Frontend.php
+++ b/Frontend/MPWPB_Frontend.php
@@ -17,6 +17,7 @@
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Shortcodes.php';
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Details_Layout.php';
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Woocommerce.php';
+				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Wc_Email_Control.php';
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Inline_WC_Checkout.php';
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Wc_Checkout_Fields_Helper.php';
 				require_once MPWPB_PLUGIN_DIR . '/Frontend/MPWPB_Native_Cart.php';

--- a/Frontend/MPWPB_Wc_Email_Control.php
+++ b/Frontend/MPWPB_Wc_Email_Control.php
@@ -1,0 +1,94 @@
+<?php
+	/*
+* @Author 		engr.sumonazma@gmail.com
+* Copyright: 	mage-people.com
+*/
+	if (!defined('ABSPATH')) {
+		die;
+	} // Cannot access pages directly.
+	/**
+	 * "Disable WooCommerce Customer Emails" -- Settings > Payment Method >
+	 * WooCommerce > Additional Settings.
+	 *
+	 * A booking is sold through a hidden WooCommerce product, so WooCommerce
+	 * treats it exactly like a shippable item and mails the customer its stock
+	 * order notifications ("Your order is now processing", "Your order is
+	 * complete"). Those read as shipment confirmations and confuse booking
+	 * customers, who expect a booking confirmation instead.
+	 *
+	 * With this setting on, the automatic CUSTOMER order emails are suppressed
+	 * for orders that consist solely of bookings, and the plugin's own booking
+	 * confirmation / PDF-ticket email (Settings > Email, PRO) takes their place.
+	 *
+	 * Deliberately NOT suppressed:
+	 *  - Admin/shop-manager notifications (new_order, cancelled_order,
+	 *    failed_order) -- orders must still "come in" to the shop owner.
+	 *  - Admin-triggered emails (customer_invoice, customer_note) -- a human
+	 *    pressed a button expecting mail to go out; silently dropping those
+	 *    would be a bug, not a feature.
+	 *  - Any order that also contains a normal shop product; that customer
+	 *    still needs WooCommerce's shipping/processing mail.
+	 *
+	 * Default is 'off', so existing sites keep their current behaviour until an
+	 * admin opts in.
+	 */
+	if (!class_exists('MPWPB_Wc_Email_Control')) {
+		class MPWPB_Wc_Email_Control {
+			/**
+			 * Automatic, order-status driven customer emails.
+			 */
+			const CUSTOMER_EMAIL_IDS = [
+				'customer_on_hold_order',
+				'customer_processing_order',
+				'customer_completed_order',
+				'customer_refunded_order',
+				'customer_partially_refunded_order',
+			];
+			public function __construct() {
+				foreach (self::CUSTOMER_EMAIL_IDS as $email_id) {
+					add_filter('woocommerce_email_enabled_' . $email_id, [$this, 'maybe_disable_customer_email'], 99, 2);
+				}
+			}
+			public static function is_enabled(): bool {
+				return MPWPB_Global_Function::get_payment_setting('wc_disable_customer_emails', 'off') === 'on';
+			}
+			/**
+			 * WC_Email::is_enabled() runs this filter both when an email is about
+			 * to be sent (with the order as $object) and on the WooCommerce email
+			 * settings screen (where $object is null). Only the first case may be
+			 * overridden -- otherwise the settings screen would show every booking
+			 * email as disabled.
+			 *
+			 * @param bool  $enabled Whether WooCommerce would send this email.
+			 * @param mixed $object  The order being mailed, or null.
+			 * @return bool
+			 */
+			public function maybe_disable_customer_email($enabled, $object = null) {
+				if (!$enabled || !self::is_enabled()) {
+					return $enabled;
+				}
+				return self::is_booking_only_order($object) ? false : $enabled;
+			}
+			/**
+			 * True only when every line item on the order is a booking service.
+			 * A mixed cart (booking + a real product that does ship) keeps
+			 * WooCommerce's emails, because that customer still needs them.
+			 */
+			public static function is_booking_only_order($order): bool {
+				if (!class_exists('WC_Order') || !$order instanceof WC_Order) {
+					return false;
+				}
+				$items = $order->get_items();
+				if (empty($items)) {
+					return false;
+				}
+				foreach ($items as $item) {
+					if (get_post_type(absint($item->get_meta('_mpwpb_id', true))) !== MPWPB_Function::get_cpt()) {
+						return false;
+					}
+				}
+				return true;
+			}
+		}
+		new MPWPB_Wc_Email_Control();
+	}

--- a/Frontend/MPWPB_Woocommerce.php
+++ b/Frontend/MPWPB_Woocommerce.php
@@ -781,6 +781,7 @@
 				if ($order_status == 'failed') {
 					return;
 				}
+				$booking_created = false;
 				foreach ($line_items as $line_item) {
 					$post_id = $line_item['post_id'] ?? 0;
 					if (get_post_type($post_id) != MPWPB_Function::get_cpt()) {
@@ -872,6 +873,7 @@
 						$data['mpwpb_billing_address'] = trim(($billing['address_1'] ?? '') . ' ' . ($billing['address_2'] ?? ''));
 						$booking_data = apply_filters('add_mpwpb_booking_data', $data, $post_id);
 						$new_booking_id = self::add_cpt_data('mpwpb_booking', $booking_data['mpwpb_billing_name'], $booking_data);
+						$booking_created = $booking_created || (bool) $new_booking_id;
 						if ($new_booking_id && $amount_due > 0 && class_exists('MPWPB_Booking_History') && class_exists('MPWPB_Partial_Payment')) {
 							MPWPB_Booking_History::log(
 								$new_booking_id,
@@ -903,6 +905,99 @@
 						}
 					}
 				}
+				if ($booking_created) {
+					self::send_booking_confirmation_mail($order_id);
+				}
+			}
+			/**
+			 * Asks the booking confirmation / PDF-ticket mailer to run for this order.
+			 *
+			 * That email is fully configurable (Settings > Email: subject, body,
+			 * placeholders, admin notification address) and PRO listens on
+			 * 'mpwpb_send_mail' to send it -- but nothing anywhere in either
+			 * plugin ever fired that action, so the email was silently never
+			 * sent no matter how it was configured. This is the missing trigger.
+			 *
+			 * Called when the bookings are created and again on every later order
+			 * status transition. Which of those actually produce an email is the
+			 * mailer's decision, driven by the "Send Email on" status list --
+			 * this side deliberately does no filtering and no de-duplication, so
+			 * a status the admin ticked can never be swallowed here before the
+			 * mailer has looked at it.
+			 *
+			 * Works for both order backends: a WooCommerce order and the native
+			 * mpwpb_order used by Custom Payment / standalone mode.
+			 */
+			public static function send_booking_confirmation_mail($order_id): void {
+				$order_id = absint($order_id);
+				if (!$order_id) {
+					return;
+				}
+				do_action('mpwpb_send_mail', $order_id);
+			}
+			/**
+			 * Which order statuses this order has already been ticket-mailed for.
+			 *
+			 * Recorded PER STATUS, not as one all-or-nothing flag. "Send Email on"
+			 * (Settings > Email) is a list of up to four statuses, and the admin
+			 * ticking two of them means "mail the customer when the order reaches
+			 * either one" -- with a single boolean flag the first match consumed
+			 * it and every later status the admin had ticked was silently
+			 * skipped, so only one of the four could ever fire.
+			 *
+			 * Per-status still means never twice for the same status, so a
+			 * retried gateway callback, a re-saved order or a second page load
+			 * cannot duplicate an email.
+			 *
+			 * Stored through the order object for WooCommerce orders so it works
+			 * under HPOS, where order meta does not live in wp_postmeta.
+			 */
+			private static function get_ticket_mail_log($order_id): array {
+				$order = function_exists('wc_get_order') ? wc_get_order($order_id) : false;
+				$raw = $order
+					? $order->get_meta('_mpwpb_confirmation_mail_sent', true)
+					: get_post_meta($order_id, 'mpwpb_confirmation_mail_sent', true);
+				if (is_array($raw)) {
+					return array_values(array_filter($raw));
+				}
+				return $raw === '' || $raw === null ? [] : array_values(array_filter(array_map('trim', explode(',', (string) $raw))));
+			}
+			public static function ticket_mail_sent($order_id, $status = ''): bool {
+				$order_id = absint($order_id);
+				if (!$order_id) {
+					return true;
+				}
+				$sent = self::get_ticket_mail_log($order_id);
+				// 'yes' is the earlier all-or-nothing flag. Treat it as "already
+				// mailed, whatever the status" so an order mailed under the old
+				// behaviour is never mailed again after an update.
+				if (in_array('yes', $sent, true)) {
+					return true;
+				}
+				if ($status === '') {
+					return !empty($sent);
+				}
+				return in_array($status, $sent, true);
+			}
+			public static function mark_ticket_mail_sent($order_id, $status = ''): void {
+				$order_id = absint($order_id);
+				if (!$order_id) {
+					return;
+				}
+				$status = $status !== '' ? $status : 'yes';
+				$sent = self::get_ticket_mail_log($order_id);
+				if (in_array($status, $sent, true)) {
+					return;
+				}
+				$sent[] = $status;
+				$value = implode(',', $sent);
+				$order = function_exists('wc_get_order') ? wc_get_order($order_id) : false;
+				if ($order) {
+					$order->update_meta_data('_mpwpb_confirmation_mail_sent', $value);
+					$order->save();
+					return;
+				}
+				update_post_meta($order_id, 'mpwpb_confirmation_mail_sent', $value);
 			}
 			public function order_status_changed($order_id) {
 				$order = wc_get_order($order_id);
@@ -914,11 +1009,20 @@
 				// wasn't already created on an earlier status.
 				$this->maybe_create_bookings_for_order($order_id, $order);
 				$order_status = $order->get_status();
+				$has_booking = false;
 				foreach ($order->get_items() as $item_id => $item_values) {
 					$post_id = wc_get_order_item_meta($item_id, '_mpwpb_id');
 					if (get_post_type($post_id) == MPWPB_Function::get_cpt()) {
+						$has_booking = true;
 						$this->wc_order_status_change($order_status, $post_id, $order_id);
 					}
+				}
+				// The ticket email can be restricted to certain order statuses
+				// ("Send Email on", Settings > Email), so an order confirmed while
+				// still pending gets its ticket here, on the transition that finally
+				// reaches an allowed status. No-op once the mail has been sent.
+				if ($has_booking) {
+					self::send_booking_confirmation_mail($order_id);
 				}
 			}
 			//**************************//

--- a/assets/frontend/mpwpb-booking-tree.js
+++ b/assets/frontend/mpwpb-booking-tree.js
@@ -552,6 +552,70 @@
 		});
 	}
 
+	// Full-calendar layout (.mpwpb-date-calendar, "Date Picker Layout" =
+	// Full Calendar). display_booking_date() renders every month the booking
+	// window touches as its own .mpwpb-date-calendar-month grid; this shows
+	// one at a time and repurposes the header's .prev/.next arrows to step
+	// whole months instead of a handful of days. A 90-day window is 3-4
+	// arrow clicks end to end rather than a dozen, and the month name is
+	// always on screen.
+	function initDateCalendarPagination($registration) {
+		$registration.find('.mpwpb-date-calendar').each(function () {
+			var $calendar = $(this);
+			if ($calendar.data('mpwpbCalendarPaged')) {
+				return;
+			}
+			$calendar.data('mpwpbCalendarPaged', true);
+
+			var $months = $calendar.children('.mpwpb-date-calendar-month');
+			if (!$months.length) {
+				return;
+			}
+			// Open on the month holding the pre-selected date, not always the
+			// first one -- the default active date is the first one that still
+			// has free slots, which can be in a later month.
+			var current = $months.index($months.filter(function () {
+				return $(this).find('.mpwpb_get_date_selected').length > 0;
+			}).first());
+			if (current < 0) {
+				current = 0;
+			}
+			var $nav = $calendar.closest('.mpwpb_date_carousel').find('#mpwpb_carousel_area').first();
+
+			function renderMonth() {
+				$months.hide().eq(current).show();
+				$nav.toggle($months.length > 1);
+				$nav.find('.prev').toggleClass('mpDisabled', current === 0);
+				$nav.find('.next').toggleClass('mpDisabled', current >= $months.length - 1);
+			}
+
+			$nav.on('click', '.prev', function () {
+				if (current > 0) {
+					current--;
+					renderMonth();
+				}
+			});
+			$nav.on('click', '.next', function () {
+				if (current < $months.length - 1) {
+					current++;
+					renderMonth();
+				}
+			});
+
+			// Picking a date in another month (recurring booking, or any code
+			// that moves the selection) should bring that month into view.
+			$calendar.on('click', '.mpwpb_get_date', function () {
+				var index = $months.index($(this).closest('.mpwpb-date-calendar-month'));
+				if (index > -1 && index !== current) {
+					current = index;
+					renderMonth();
+				}
+			});
+
+			renderMonth();
+		});
+	}
+
 	// "Proceed to Checkout" is forced always-visible via CSS (see
 	// mpwpb-service-page-modern.css) instead of the plain display:none/
 	// fadeIn toggling mpwpb_registration.js and mpwpb_recurring_booking.js
@@ -573,6 +637,7 @@
 			initExtraServiceDetails($(this));
 			initExtraServiceLayout($(this));
 			initDateGridPagination($(this));
+			initDateCalendarPagination($(this));
 			updateCheckoutReadyState($(this));
 		});
 	});

--- a/assets/frontend/mpwpb-service-page-modern.css
+++ b/assets/frontend/mpwpb-service-page-modern.css
@@ -1716,3 +1716,67 @@ div.mpwpb_popup[data-popup="#mpwpb_static_popup"] .mpwpb-reorder-notice-message{
 	}
 	.mpwpb-static-template .mpwpb_order_proceed_area .mpwpb-inline-retry-checkout{grid-column:1/-1;width:100%;}
 }
+
+/* -------------------------------------------------------------------- *
+ *  Date picker -> full month calendar ("Date Picker Layout" = Full
+ *  Calendar, Settings > Global). display_booking_date() emits one
+ *  .mpwpb-date-calendar-month per month in the booking window, each a
+ *  real 7-column grid; initDateCalendarPagination() in
+ *  mpwpb-booking-tree.js shows one month at a time and turns the header
+ *  arrows into month navigation.
+ *
+ *  Deliberately NOT scoped to the static template / sidebar popup the way
+ *  the .mpwpb-date-grid rules above are: this layout is a global setting,
+ *  so it has to look right in every template and in the popup alike.
+ * -------------------------------------------------------------------- */
+.mpwpb_style .mpwpb-date-calendar{display:block !important;width:100%;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-calendar-month{display:block;width:100%;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-month-label{
+	font-size:15px;font-weight:700;color:#1e293b;text-align:center;margin:0 0 10px;text-transform:capitalize;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-weekday-row,
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-month-days{
+	display:grid;grid-template-columns:repeat(7,minmax(0,1fr));gap:6px;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-weekday-row{margin-bottom:6px;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-weekday-row span{
+	font-size:11px;font-weight:700;color:#94a3b8;text-align:center;text-transform:uppercase;letter-spacing:.02em;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-blank{
+	display:flex;align-items:center;justify-content:center;min-height:38px;
+	font-size:13px;color:#e2e8f0;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb_date_time_line{
+	width:auto !important;flex:none !important;margin:0 !important;
+}
+/* The weekday is already the column header here, so the per-cell "Mon /
+   Today" label would only repeat it and force the cells taller. */
+.mpwpb_style .mpwpb-date-calendar .mptrs_day_with_date{display:none !important;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_date,
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_close_date,
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_date_passed{
+	display:flex !important;flex-direction:column;align-items:center;justify-content:center;gap:2px;
+	width:100%;height:100%;min-height:38px !important;padding:6px 2px !important;
+	border:1px solid #e5e9f0 !important;border-radius:10px;margin:0 !important;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb-date-number{font-size:15px;font-weight:700;color:#1e293b;line-height:1.1;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_date_selected .mpwpb-date-number{color:#fff !important;}
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_close_date,
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_date_passed{
+	background-color:#f8fafc !important;cursor:not-allowed !important;opacity:.6;
+}
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_close_date .mpwpb-date-number,
+.mpwpb_style .mpwpb-date-calendar .mpwpb_get_date_passed .mpwpb-date-number{color:#94a3b8 !important;}
+/* "Closed"/"Passed" spelled out does not fit a calendar cell -- the greyed
+   cell already says it, and the title attribute carries the full date. */
+.mpwpb_style .mpwpb-date-calendar .mpwpb_close_date,
+.mpwpb_style .mpwpb-date-calendar .mpwpb_date_passed_label{
+	font-size:8px;font-weight:600;color:#cbcfcf;text-transform:uppercase;line-height:1;
+	white-space:nowrap;overflow:hidden;text-overflow:clip;max-width:100%;
+}
+@media(max-width:420px){
+	.mpwpb_style .mpwpb-date-calendar .mpwpb-date-weekday-row,
+	.mpwpb_style .mpwpb-date-calendar .mpwpb-date-month-days{gap:4px;}
+	.mpwpb_style .mpwpb-date-calendar .mpwpb_close_date,
+	.mpwpb_style .mpwpb-date-calendar .mpwpb_date_passed_label{display:none;}
+}

--- a/assets/frontend/mpwpb_registration.css
+++ b/assets/frontend/mpwpb_registration.css
@@ -1986,10 +1986,29 @@ button.mpwpb_service_button.mActive:hover{
 .mpwpb_get_close_date
 {
   background-color: #fbeeee  !important;
-  cursor: pointer;
+  cursor: not-allowed;
   padding: 15px !important;
   min-height: 80px !important;
   border-radius: 10px;
+  text-align: center;
+}
+
+/* A closed day now shows the same weekday + day-number card as every other
+   day, with a "Closed" label instead of the full "12 September 2026" it used
+   to print. That was the only place the month appeared anywhere in the
+   picker, so open days looked like they were missing information the closed
+   ones had. */
+.mpwpb_get_close_date .mptrs_day_with_date,
+.mpwpb_get_close_date .mpwpb-date-number{
+  color: #b98d8d !important;
+}
+
+.mpwpb_close_date{
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  color: #c2a0a0;
+  text-transform: uppercase;
 }
 
 .mpwpb_get_date_passed{

--- a/inc/MPWPB_Dependencies.php
+++ b/inc/MPWPB_Dependencies.php
@@ -166,7 +166,7 @@
 				// custom
 				wp_enqueue_style('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.css', [], self::asset_version('/assets/frontend/mpwpb.css'));
 				wp_enqueue_script('mpwpb', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb.js', ['jquery'], self::asset_version('/assets/frontend/mpwpb.js'), true);
-				wp_enqueue_style('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.css', [], MPWPB_VERSION);
+				wp_enqueue_style('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.css', [], self::asset_version('/assets/frontend/mpwpb_registration.css'));
 				wp_enqueue_script('mpwpb_registration', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb_registration.js', ['jquery'], MPWPB_VERSION);
 				wp_enqueue_style('mpwpb_coupon', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-coupon.css', [], MPWPB_VERSION);
 				// Depends on mpwpb_registration (not just jquery) so the
@@ -178,7 +178,7 @@
 				wp_enqueue_script('mpwpb_payment_choice', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-payment-choice.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// Single service page redesign (hero/tabs/Overview/FAQ/Details) —
 				// pure reskin, loaded after mpwpb_registration so its overrides win.
-				wp_enqueue_style('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.css', ['mpwpb_registration'], MPWPB_VERSION);
+				wp_enqueue_style('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.css', ['mpwpb_registration'], self::asset_version('/assets/frontend/mpwpb-service-page-modern.css'));
 				wp_enqueue_script('mpwpb_service_page_modern', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-service-page-modern.js', ['jquery', 'mpwpb_registration'], MPWPB_VERSION, true);
 				// "Our services" sidebar tree expand/collapse only — selecting a
 				// service still goes through mpwpb_registration.js unchanged.
@@ -186,7 +186,7 @@
 				// Booking popup's inner picker: relocates the real category/
 				// service elements (untouched click handlers/hidden inputs)
 				// into a unified checkbox-tree — no new selection logic.
-				wp_enqueue_script('mpwpb_booking_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-booking-tree.js', ['jquery', 'mpwpb_registration', 'mpwpb_service_tree'], MPWPB_VERSION, true);
+				wp_enqueue_script('mpwpb_booking_tree', MPWPB_PLUGIN_URL . '/assets/frontend/mpwpb-booking-tree.js', ['jquery', 'mpwpb_registration', 'mpwpb_service_tree'], self::asset_version('/assets/frontend/mpwpb-booking-tree.js'), true);
 				// Account-area presentation: WooCommerce's stock Orders table
 				// reskin plus the scoped Custom Payment dashboard cards/table.
 				// Loaded after mpwpb_registration so its overrides win.

--- a/inc/MPWPB_Query.php
+++ b/inc/MPWPB_Query.php
@@ -10,8 +10,10 @@
 		class MPWPB_Query {
 			public function __construct() {}
 			public static function query_all_sold( $post_id, $date) {
-				$_seat_booked_status      = MPWPB_Global_Function::get_settings('mpwpb_global_settings', 'set_book_status', array('processing', 'completed'));
-				$seat_booked_status       = ! empty( $_seat_booked_status ) ? $_seat_booked_status : [];
+				// Always a non-empty list -- see get_seat_booked_statuses(). With an
+				// empty one every status filter below fell away, so this counted
+				// bookings of ANY status against availability, cancelled included.
+				$seat_booked_status       = MPWPB_Global_Function::get_seat_booked_statuses();
 
 				$date_filter              = ! empty( $date ) ? array(
 					'key'     => 'mpwpb_date',

--- a/mp_global/class/MPWPB_Global_Function.php
+++ b/mp_global/class/MPWPB_Global_Function.php
@@ -552,6 +552,34 @@
 			 * render_partial_payment_panel() and MPWPB_Partial_Payment::maybe_migrate_settings()
 			 * for the one-time migration off the old mpwpb_payment_method_settings keys.
 			 */
+			/**
+			 * The order statuses that count a booking as "booked" ("Seat Booked
+			 * Status", Settings > Global).
+			 *
+			 * Never returns an empty list. The raw option is a multicheck, and
+			 * saving Global Settings with none of its boxes ticked stores an
+			 * empty string -- which is a stored value, so get_settings() returns
+			 * it instead of the default, and every caller ended up with an empty
+			 * status list. That is not "count nothing", it is broken:
+			 *
+			 *  - MPWPB_Function_PRO::attendee_query() feeds the list to a
+			 *    meta_query 'IN' compare, and an empty IN builds "IN ()" -- a SQL
+			 *    syntax error, so the query returns nothing at all. The PRO Order
+			 *    List, Service Queue, calendar and (until the ticket PDF stopped
+			 *    using it) the customer's ticket all silently went empty.
+			 *  - MPWPB_Query::query_all_sold() loses its whole status filter and
+			 *    counts every booking regardless of status, so cancelled and
+			 *    failed orders keep holding seats.
+			 *
+			 * Falling back to the documented default (processing + completed) is
+			 * what an admin who never touched the setting already gets, so this
+			 * only ever repairs the broken state.
+			 */
+			public static function get_seat_booked_statuses(): array {
+				$statuses = self::get_settings('mpwpb_global_settings', 'set_book_status', array('processing', 'completed'));
+				$statuses = is_array($statuses) ? array_values(array_filter($statuses)) : array_values(array_filter((array) $statuses));
+				return !empty($statuses) ? $statuses : array('processing', 'completed');
+			}
 			public static function get_partial_payment_setting($key, $default = '') {
 				return self::get_settings('mpwpb_partial_payment_settings', $key, $default);
 			}

--- a/templates/registration/date_time_select.php
+++ b/templates/registration/date_time_select.php
@@ -13,6 +13,15 @@
 	// sliding owl-carousel entirely -- other templates (e.g. default.php)
 	// keep the carousel unchanged.
 	$mpwpb_is_static_template = MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_template', 'static.php') === 'static.php';
+	// "Date Picker Layout" (Settings > Global). The month-grid layout replaces
+	// both the wrapped grid and the carousel, because paging a long booking
+	// window a few days at a time is the problem it exists to solve.
+	$mpwpb_date_layout = MPWPB_Details_Layout::get_date_picker_layout();
+	if ( $mpwpb_date_layout === 'calendar' ) {
+		$mpwpb_date_holder_class = 'mpwpb-date-calendar';
+	} else {
+		$mpwpb_date_holder_class = $mpwpb_is_static_template ? 'mpwpb-date-grid' : 'owl-theme mpwpb-owl-carousel';
+	}
 
 	$enable_waiting_list = MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_enable_waiting_list', 'no');
 	$enable_recurring = MPWPB_Global_Function::get_post_info($post_id, 'mpwpb_enable_recurring', 'no');
@@ -77,7 +86,7 @@
 				<?php include(MPWPB_Function::template_path('layout/carousel_indicator.php')); ?>
             </header>
             <div class="" >
-                <div class="<?php echo $mpwpb_is_static_template ? 'mpwpb-date-grid' : 'owl-theme mpwpb-owl-carousel'; ?>" id="mpwpb_datetime_holder1">
+                <div class="<?php echo esc_attr( $mpwpb_date_holder_class ); ?>" id="mpwpb_datetime_holder1">
                     <?php if (sizeof($all_dates) > 0) {
                         // Computed once and passed to both calls so the date
                         // marked "selected" and the time panel shown by

--- a/templates/themes/static.php
+++ b/templates/themes/static.php
@@ -17,8 +17,23 @@
                 <div class="header-content">
                     <span class="mpwpb-hero-eyebrow"><i class="fas fa-store"></i> <?php echo esc_html(get_bloginfo('name')); ?></span>
                     <h2><?php the_title(); ?></h2>
-					<?php if (has_excerpt() || get_the_content()): ?>
-                    <p class="mpwpb-hero-subtext"><?php echo esc_html(get_the_excerpt()); ?></p>
+					<?php
+						/**
+						 * Hero subtext = the service's Excerpt, and only that.
+						 *
+						 * This used to fall back to get_the_excerpt() whenever the
+						 * editor had any content at all. With no excerpt written (and
+						 * until now no Excerpt field even registered on the CPT, see
+						 * MPWPB_CPT) WordPress auto-generated one by trimming the page
+						 * content to 55 words and appending "[...]" -- so the hero
+						 * showed a mangled slice of the page body that the admin could
+						 * not locate in any service setting, because it was never
+						 * stored anywhere. Now it prints only what was deliberately
+						 * written in the Excerpt box, and nothing when that is empty.
+						 */
+						$mpwpb_hero_subtext = has_excerpt($post_id) ? get_the_excerpt($post_id) : '';
+						if ($mpwpb_hero_subtext !== '') : ?>
+                    <p class="mpwpb-hero-subtext"><?php echo esc_html($mpwpb_hero_subtext); ?></p>
 					<?php endif; ?>
                     <!-- dispaly service static page reatings using this hook -->
 					<?php do_action('mpwpb_service_show_ratings'); ?>


### PR DESCRIPTION
Six issues reported from a live site (norahlux.red), all reproduced and fixed. Deployed and verified on that site.

## What was broken

**The booking confirmation email had no trigger at all.** `MPWPB_Pro_Mail` listens on `mpwpb_send_mail`, and no code in either plugin ever fired it. The whole Settings → Email tab was dead configuration — however it was filled in, no customer ever received anything.

**WooCommerce was mailing booking customers shipping notifications.** Bookings are sold through a hidden product, so WooCommerce sends "Your order is now processing / complete". Customers read those as shipment confirmations for a delivery that never comes.

**The date picker was unusable on a long booking window.** One card per day, paged eight at a time — a 90-day window is twelve pages of clicking. The month was invisible on open days and only ever appeared on closed ones, which printed the full `12 September 2026`.

**The service hero showed text the admin could not find.** The template printed `get_the_excerpt()`, but the post type never registered excerpt support, so no excerpt could ever be stored and WordPress auto-generated one by trimming the page body and appending `[...]`. Visible on the front end, editable nowhere, because it existed nowhere as data.

**An empty "Seat Booked Status" silently broke booking queries.** Saving Global Settings with none of its boxes ticked stores an empty string, which `get_settings()` returns instead of the default. That collapses `attendee_query()` to `meta_value IN ()` — a SQL syntax error returning zero rows for every caller — and strips `query_all_sold()` of its status filter so cancelled orders keep holding seats.

## Commits

| Commit | Change |
|---|---|
| `f7fc01e` | Fire the confirmation email; record sent-state per status so every status ticked in "Send Email on" fires |
| `14b3a51` | New "Disable WooCommerce Customer Emails" setting, scoped to booking-only orders |
| `30e6943` | New "Date Picker Layout" setting with a full month calendar |
| `ea89406` | Register excerpt support; print only a deliberately written excerpt |
| `2e95210` | `get_seat_booked_statuses()` — never returns an empty list |
| `883b4e6` | Version the three date-picker assets by mtime so fixes actually ship past CDNs |

## Compatibility

Both new settings default to current behaviour, so no existing site changes until an admin opts in. Both date-picker layouts emit identical day-cell markup, so click handling, selected state and disabled states are shared and untouched. The per-status mail flag honours the previous all-or-nothing `yes` value, so an order mailed under the old behaviour is never mailed again.

## Testing

Verified on the live site after deploy: calendar renders four localised month grids (`augustus`…`november 2026`) with a Monday-start weekday header, hero subtext gone, closed days consistent, no PHP notices, ticket query returns 2 rows for an order where the old one returned 0. All touched files lint clean on PHP 8.

Pairs with magepeopleteam/service-booking-manager-pro#39.
