### PR TITLE
Make the plugin translatable: ship a POT and a WPML config

### DIFF
--- a/languages/service-booking-manager.pot
+++ b/languages/service-booking-manager.pot
@@ -1,0 +1,14340 @@
+# Copyright (C) 2026 MagePeople Team
+# This file is distributed under the GPLv2 or later.
+msgid ""
+msgstr ""
+"Project-Id-Version: Appointment Booking Plugin for WooCommerce – All-in-One Service Manager 1.4.0\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/service-booking-manager\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"POT-Creation-Date: 2026-08-10T07:45:16+00:00\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"X-Generator: WP-CLI 2.12.0\n"
+"X-Domain: service-booking-manager\n"
+
+#. Plugin Name of the plugin
+#: MPWPB_Plugin.php
+msgid "Appointment Booking Plugin for WooCommerce – All-in-One Service Manager"
+msgstr ""
+
+#. Plugin URI of the plugin
+#: MPWPB_Plugin.php
+msgid "http://mage-people.com"
+msgstr ""
+
+#. Description of the plugin
+#: MPWPB_Plugin.php
+msgid "A complete solution for Any kind of service booking."
+msgstr ""
+
+#. Author of the plugin
+#: MPWPB_Plugin.php
+msgid "MagePeople Team"
+msgstr ""
+
+#. Author URI of the plugin
+#: MPWPB_Plugin.php
+msgid "http://www.mage-people.com/"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:16
+#: Admin/MPWPB_Coupon_List.php:115
+#: Admin/MPWPB_Coupon_Settings.php:112
+#: templates/layout/coupon_list.php:167
+msgid "Discount"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:17
+msgid "Choose how this coupon discounts a booking."
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:21
+#: Admin/settings/Happy_Hours.php:119
+msgid "Discount Type"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:23
+msgid "Fixed Discount ($ off)"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:24
+msgid "Percentage Discount (% off)"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:25
+msgid "Fixed Booking Price (matched service becomes a flat price)"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:26
+msgid "Free Booking (100% off)"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:35
+msgid "Percentage Off (%)"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:37
+msgid "Flat Price"
+msgstr ""
+
+#: Admin/coupon-settings/Discount.php:39
+msgid "Amount Off"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:18
+#: Admin/MPWPB_Coupon_List.php:114
+#: Admin/MPWPB_Coupon_Settings.php:109
+#: Admin/MPWPB_Quick_Setup.php:59
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:102
+msgid "General"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:19
+msgid "Coupon code and validity window. The coupon name (post title) is set at the top of this screen."
+msgstr ""
+
+#: Admin/coupon-settings/General.php:23
+msgid "Coupon Code"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:24
+msgid "e.g. SUMMER25"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:29
+#: Admin/MPWPB_Help_Guide_Content.php:79
+#: Admin/MPWPB_Help_Guide_Content.php:86
+#: Admin/MPWPB_Help_Guide_Content.php:181
+#: Admin/settings/Extra_service.php:274
+#: Admin/settings/Service.php:245
+#: Admin/settings/Service.php:344
+msgid "Description"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:35
+msgid "Start Date"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:39
+msgid "Expiry Date"
+msgstr ""
+
+#: Admin/coupon-settings/General.php:44
+msgid "Status is controlled by the Publish/Draft state of this post (top-right panel). Published = active, Draft = inactive."
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:20
+#: Admin/MPWPB_Coupon_List.php:117
+#: Admin/MPWPB_Coupon_Settings.php:118
+msgid "Restrictions"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:21
+msgid "Price, quantity, and customer rules a booking must meet for this coupon to apply."
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:24
+msgid "Price Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:26
+msgid "Minimum Booking Total"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:27
+#: Admin/coupon-settings/Restrictions.php:38
+msgid "No minimum"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:30
+msgid "Maximum Booking Total"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:31
+#: Admin/coupon-settings/Restrictions.php:42
+msgid "No maximum"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:35
+msgid "Quantity Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:37
+msgid "Minimum Quantity"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:41
+msgid "Maximum Quantity"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:46
+msgid "Customer Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:48
+msgid "Booking History"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:50
+#: Admin/coupon-settings/Restrictions.php:58
+msgid "No restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:51
+msgid "First Booking Only"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:52
+msgid "Returning Customer Only"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:56
+msgid "Account Status"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:59
+msgid "Guest Checkout Only"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:60
+msgid "Logged-in Customers Only"
+msgstr ""
+
+#: Admin/coupon-settings/Restrictions.php:63
+msgid "Both rules apply together when set — e.g. \"First Booking Only\" + \"Logged-in Customers Only\" requires both."
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:22
+#: Admin/MPWPB_Coupon_Settings.php:121
+msgid "Scheduling & Staff"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:23
+msgid "Restrict this coupon to certain booking dates/times, and certain staff."
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:26
+msgid "Day Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:28
+msgid "Only Valid For"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:30
+msgid "Any Day"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:31
+msgid "Weekdays Only"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:32
+msgid "Weekends Only"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:37
+msgid "Specific Dates"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:39
+#: Admin/coupon-settings/Scheduling_Staff.php:54
+#: Admin/MPWPB_Native_Checkout_Settings.php:693
+#: Admin/MPWPB_Native_Checkout_Settings.php:732
+msgid "Mode"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:41
+msgid "No Date Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:42
+msgid "Only These Dates"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:43
+msgid "Blackout These Dates"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:47
+msgid "Dates (comma-separated, YYYY-MM-DD)"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:52
+msgid "Time Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:56
+msgid "Any Time"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:57
+msgid "Time of Day"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:58
+msgid "Specific Time Range"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:62
+msgid "Bucket"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:64
+msgid "Morning (12:00am–11:59am)"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:65
+msgid "Afternoon (12:00pm–4:59pm)"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:66
+msgid "Evening (5:00pm–11:59pm)"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:70
+#: Admin/MPWPB_Staff_DashBoard.php:1171
+msgid "From"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:74
+#: Admin/MPWPB_Staffs.php:337
+#: Admin/MPWPB_Staffs.php:441
+#: Admin/MPWPB_Staffs.php:450
+#: Admin/MPWPB_Staff_DashBoard.php:1175
+#: Admin/MPWPB_Staff_Members.php:386
+#: Admin/MPWPB_Staff_Members.php:496
+#: Admin/MPWPB_Staff_Members.php:505
+msgid "To"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:103
+msgid "Staff Restriction"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:105
+#: Admin/coupon-settings/Services.php:25
+msgid "Applies To"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:107
+msgid "All Staff"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:108
+msgid "Only Selected Staff"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:109
+msgid "Exclude Selected Staff"
+msgstr ""
+
+#: Admin/coupon-settings/Scheduling_Staff.php:113
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:848
+#: Admin/settings/Staff_Member.php:107
+#: templates/registration/date_time_select.php:205
+msgid "Select Staff"
+msgstr ""
+
+#: Admin/coupon-settings/Services.php:20
+#: Admin/MPWPB_Coupon_List.php:116
+#: Admin/MPWPB_Coupon_Settings.php:115
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:527
+#: Frontend/MPWPB_Native_Checkout.php:264
+#: Frontend/MPWPB_Recurring_Account_Manager.php:94
+msgid "Services"
+msgstr ""
+
+#: Admin/coupon-settings/Services.php:21
+msgid "Restrict this coupon to specific services, or allow it on every service."
+msgstr ""
+
+#: Admin/coupon-settings/Services.php:27
+#: Admin/MPWPB_Analytics_Dashboard.php:82
+#: Admin/MPWPB_Native_Order_List.php:106
+#: Admin/MPWPB_Reviews_Admin.php:170
+#: Admin/MPWPB_Reviews_Admin.php:374
+#: Admin/MPWPB_Staff_DashBoard.php:1181
+#: Admin/settings/Pricing.php:58
+#: templates/layout/service_list.php:292
+msgid "All Services"
+msgstr ""
+
+#: Admin/coupon-settings/Services.php:28
+msgid "Specific Service(s)"
+msgstr ""
+
+#: Admin/coupon-settings/Services.php:34
+msgid "Select Service(s)"
+msgstr ""
+
+#: Admin/coupon-settings/Usage_Limits.php:17
+#: Admin/MPWPB_Coupon_Settings.php:124
+msgid "Usage Limits"
+msgstr ""
+
+#: Admin/coupon-settings/Usage_Limits.php:18
+msgid "Cap how many times this coupon can be redeemed."
+msgstr ""
+
+#: Admin/coupon-settings/Usage_Limits.php:22
+msgid "Total Usage Limit"
+msgstr ""
+
+#: Admin/coupon-settings/Usage_Limits.php:23
+#: Admin/coupon-settings/Usage_Limits.php:27
+#: Admin/MPWPB_Settings_Global.php:597
+#: templates/layout/coupon_list.php:47
+msgid "Unlimited"
+msgstr ""
+
+#: Admin/coupon-settings/Usage_Limits.php:26
+msgid "Usage Limit Per Customer"
+msgstr ""
+
+#. translators: %d: number of times this coupon has been used so far
+#: Admin/coupon-settings/Usage_Limits.php:34
+#, php-format
+msgid "Used %d time(s) so far."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:28
+#: Admin/data/MPWPB_Business_Templates_Data.php:33
+msgid "Car Wash & Auto Detailing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:32
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+msgid "Sparkle Auto Wash & Detailing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:34
+msgid "Professional wash & detailing, booked online in minutes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:38
+msgid "Wash Packages"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:39
+msgid "Detailing & Add-ons"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:44
+msgid "Basic Exterior Wash"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:45
+msgid "Exterior hand wash, wheel clean, and towel dry. A quick refresh between full details."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:47
+msgid "Interior Vacuum & Wipe Down"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:48
+msgid "Full vacuum of seats, carpets, and trunk plus a wipe-down of the dash, console, and door panels."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:50
+msgid "Full Detail (Interior + Exterior)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:51
+msgid "Complete wash, clay bar, machine wax, and full interior deep clean -- carpets, seats, and glass."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:53
+msgid "Wax & Polish"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:54
+msgid "Hand-applied wax and polish for a deep, glossy, protective finish that lasts weeks."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:56
+msgid "Engine Bay Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:57
+msgid "Safe degreasing and detailing of the engine bay, dressed for a like-new look."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:63
+msgid "Tire Shine & Dressing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:63
+msgid "Glossy, long-lasting tire dressing applied to all four wheels."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:64
+msgid "Air Freshener"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:64
+msgid "Choice of scent, clipped to your vent for weeks of fresh air."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:65
+msgid "Pet Hair Removal"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:65
+msgid "Specialized tools to lift embedded pet hair from seats and carpet."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:69
+#: Admin/data/MPWPB_Business_Templates_Data.php:1011
+msgid "Eco-Friendly Cleaning Products"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:70
+msgid "Hand Wash & Hand Dry -- No Brush Damage"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:71
+msgid "Same-Day Appointments"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:72
+msgid "Free Re-Wash Guarantee"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+msgid "keeps your car looking its best with hand-wash care and eco-friendly products."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+msgid "Pick a wash or detail package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+msgid "Choose your date and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "Add any extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:74
+msgid "Confirm and drive in."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:75
+msgid "We use biodegradable, non-toxic cleaning agents and soft-touch hand-wash methods on every vehicle. Our detailing team is trained on all vehicle types, from compacts to full-size SUVs."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:78
+msgid "Do I need an appointment?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:78
+msgid "Walk-ins are welcome, but booking online guarantees your time slot."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:79
+msgid "How long does a full detail take?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:79
+msgid "A full interior + exterior detail typically takes about 2 hours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:80
+msgid "What payment methods do you accept?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:80
+msgid "We accept all major cards and contactless payment on-site."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:81
+msgid "Do you offer a membership for regular washes?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:81
+msgid "Yes -- see our monthly detailing membership with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:105
+msgid "Fast and thorough"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:105
+msgid "In and out in under an hour and my car looked brand new. Will be back."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:106
+msgid "Great with pet hair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:106
+msgid "They actually got the dog hair out of my back seat. Impressed."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:107
+#: Admin/data/MPWPB_Business_Templates_Data.php:1543
+msgid "Good value"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:107
+msgid "Solid basic wash for the price. Would love a few more time slots on Saturdays."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:108
+msgid "Booking was easy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:108
+msgid "Loved being able to pick my time slot online instead of calling."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:114
+#: Admin/data/MPWPB_Business_Templates_Data.php:119
+msgid "Hair Salon & Barbershop"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:118
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+msgid "Luxe Hair Studio & Barbershop"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:120
+msgid "Cuts, color, and styling -- book your chair online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:124
+msgid "Haircuts & Styling"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:125
+msgid "Color & Treatments"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:130
+msgid "Women's Haircut & Blow-Dry"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:131
+msgid "Consultation, precision cut, and a full blow-dry finish tailored to your style."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:133
+msgid "Men's Haircut"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:134
+msgid "Classic or modern cut with clippers and scissor work, finished with a style."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:136
+msgid "Beard Trim & Shape-Up"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:137
+msgid "Hot towel prep, precision beard trim, and clean edge line-up."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:139
+msgid "Full Color"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:140
+msgid "All-over single-process color using ammonia-light, professional-grade dye."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:142
+msgid "Balayage & Highlights"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:143
+msgid "Hand-painted highlights for a natural, sun-kissed gradient. Includes toner and gloss."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:145
+msgid "Deep Conditioning Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:146
+msgid "Intensive moisture mask with scalp massage to repair and strengthen hair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:152
+msgid "Scalp Massage Add-On"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:152
+msgid "10-minute relaxing scalp massage added to any service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:153
+msgid "Blow-Dry Only"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:153
+msgid "Wash and professional blow-dry style without a cut."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:154
+msgid "Hair Gloss Finish"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:154
+msgid "Glossing treatment for extra shine after color services."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:158
+msgid "Certified Colorists on Staff"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:159
+msgid "Premium, Cruelty-Free Products"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:160
+msgid "Complimentary Consultation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:161
+msgid "Late Evening Appointments Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+msgid "pairs skilled stylists with a relaxed, welcoming chair-side experience."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+msgid "Choose a cut, color, or treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+msgid "Pick your preferred stylist and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:163
+msgid "Confirm and we will see you in the chair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:164
+msgid "Every stylist trains continuously on the latest cutting and color techniques. We use ammonia-light, professional color lines and finish every visit with a style consultation for at-home care."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:167
+msgid "Do you require a deposit for color services?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:167
+msgid "Longer color services may require a small deposit at booking, refundable against your final bill."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:168
+msgid "Can I request a specific stylist?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:168
+msgid "Yes, you can choose your preferred stylist when booking your appointment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:169
+msgid "What if I need to reschedule?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:169
+msgid "Just contact us as early as possible and we will find you a new time slot."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:170
+msgid "Do you offer bridal or event styling?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:170
+msgid "Yes -- ask about our event styling packages when you book."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:194
+msgid "Best balayage in town"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:194
+msgid "Chloe nailed exactly the look I wanted. Booking online was so easy too."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:195
+msgid "Great barbershop experience"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:195
+msgid "Marcus gives the cleanest fade around. Always on time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:196
+msgid "Lovely salon"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:196
+msgid "Relaxing atmosphere and friendly staff. A bit pricey but worth it."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:197
+msgid "Loved the scalp massage add-on"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:197
+msgid "Such a nice touch after a long week. Will book again."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:203
+#: Admin/data/MPWPB_Business_Templates_Data.php:208
+msgid "Medical Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:207
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+msgid "Riverside Family Medical Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:209
+msgid "Same-week appointments with our family medicine team"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:213
+msgid "General Consultations"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:214
+msgid "Diagnostics & Screening"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:219
+#: Admin/data/MPWPB_Business_Templates_Data.php:682
+msgid "New Patient Consultation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:220
+msgid "Full intake, medical history review, and consultation with a family physician."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:222
+msgid "Follow-Up Consultation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:223
+msgid "Progress review and treatment adjustment for existing patients."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:225
+msgid "Annual Physical Exam"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:226
+msgid "Comprehensive yearly check-up covering vitals, bloodwork referral, and preventive screening."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:228
+msgid "Vaccination"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:229
+msgid "Routine and travel vaccinations administered by a licensed nurse."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:231
+msgid "Blood Pressure & Vitals Check"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:232
+msgid "Quick vitals check -- blood pressure, pulse, temperature, and weight."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:234
+msgid "Lab Work Referral & Review"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:235
+msgid "Lab order, sample collection coordination, and results review appointment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:241
+msgid "Printed Medical Summary"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:241
+msgid "A printed copy of your visit summary and recommendations to take home."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:242
+msgid "Telehealth Follow-Up Call"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:242
+msgid "A 15-minute phone follow-up after your appointment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:243
+msgid "Extended Consultation Time"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:243
+msgid "Add 15 extra minutes to discuss additional concerns."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:247
+msgid "Board-Certified Physicians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:248
+#: Admin/data/MPWPB_Business_Templates_Data.php:697
+#: Admin/data/MPWPB_Business_Templates_Data.php:1139
+msgid "Same-Week Appointments"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:249
+msgid "On-Site Lab Coordination"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:250
+msgid "Insurance Billing Support"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+msgid "provides accessible, same-week primary care for the whole family."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+msgid "Select a consultation or screening type."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+msgid "Choose a date and time that works for you."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "Add any extras you need."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:252
+msgid "Confirm and arrive 10 minutes early with your ID."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:253
+msgid "Our clinicians are board-certified in family medicine and work with an on-site nursing team for vaccinations, vitals, and lab coordination. We accept most major insurance plans."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:256
+msgid "What should I bring to my first appointment?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:256
+msgid "Please bring a photo ID, your insurance card, and a list of any current medications."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:257
+msgid "Do you accept insurance?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:257
+msgid "We accept most major insurance providers. Contact us to confirm your specific plan."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:258
+msgid "How soon can I get an appointment?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:258
+msgid "We typically offer appointments within the same week, subject to availability."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:259
+msgid "Can I get a prescription refill without an in-person visit?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:259
+msgid "Book a Telehealth Follow-Up Call add-on and our physician will review your refill request."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:281
+msgid "Attentive and thorough"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:281
+msgid "Dr. Whitfield took the time to actually listen. Best clinic experience I have had."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:282
+msgid "Fast and easy booking"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:282
+msgid "Got an appointment within two days. Very smooth online booking."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:283
+msgid "Good clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:283
+msgid "Short wait time and friendly front desk. Would recommend."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:284
+msgid "Great with my whole family"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:284
+msgid "We switched our whole family here. Dr. Okafor is wonderful with kids."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:290
+#: Admin/data/MPWPB_Business_Templates_Data.php:295
+msgid "Auto Repair & Vehicle Maintenance"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:294
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+msgid "Precision Auto Repair & Maintenance"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:296
+msgid "Certified repairs and maintenance, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:299
+msgid "Diagnostics & Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:300
+msgid "Repairs & Maintenance"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:304
+msgid "Full Vehicle Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:304
+msgid "Multi-point inspection covering brakes, fluids, tires, and belts."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:305
+msgid "Check Engine Light Diagnostic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:305
+msgid "Computer diagnostic scan to identify the cause of a warning light."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:306
+msgid "Oil Change & Filter"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:306
+msgid "Full synthetic or conventional oil change with a new filter."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:307
+msgid "Brake Pad Replacement"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:307
+msgid "Front or rear brake pad replacement with a rotor inspection."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:308
+msgid "Battery Replacement"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:308
+msgid "Battery testing and replacement with a new, warrantied battery."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:312
+msgid "Wiper Blade Replacement"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:312
+msgid "New wiper blades installed front and rear."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:313
+#: Admin/data/MPWPB_Business_Templates_Data.php:1384
+msgid "Air Filter Replacement"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:313
+msgid "Fresh engine air filter for better performance and mileage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:314
+msgid "Tire Rotation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:314
+msgid "Rotate all four tires to promote even wear."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:317
+msgid "ASE-Certified Technicians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:318
+msgid "Genuine OEM Parts Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:319
+msgid "Free Inspection with Any Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:320
+msgid "Same-Day Service on Most Repairs"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+msgid "keeps your vehicle running safely with certified, honest repairs."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+msgid "Choose a diagnostic or repair service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+msgid "Pick a drop-off time that works for you."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+msgid "We inspect and confirm any extra work before starting."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:322
+msgid "Pick up your vehicle, repaired and road-ready."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:323
+msgid "Our ASE-certified technicians work on all major makes and models using genuine or OEM-equivalent parts, with every repair backed by a workmanship warranty."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:325
+msgid "Do you offer loaner cars?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:325
+msgid "We offer a local shuttle service while your vehicle is in for repair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:326
+msgid "Will you call before doing extra work?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:326
+msgid "Yes -- we always call with a quote before performing any work beyond the original request."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:327
+#: Admin/data/MPWPB_Business_Templates_Data.php:1209
+msgid "Do repairs come with a warranty?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:327
+msgid "All repairs include a 12-month/12,000-mile workmanship warranty."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:328
+msgid "Can I get on a maintenance reminder plan?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:328
+msgid "Yes -- ask about our monthly maintenance reminder plan with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:344
+msgid "Honest shop"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:344
+msgid "They called before doing anything extra. Refreshing to find an honest mechanic."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:345
+msgid "Fast oil change"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:345
+msgid "In and out in 30 minutes exactly as booked."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:346
+msgid "Good brake job"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:346
+msgid "Brakes feel great again. Slightly pricier than I expected but worth it."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:347
+msgid "Reliable and quick"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:347
+msgid "My check engine light diagnostic was fast and clearly explained."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:353
+#: Admin/data/MPWPB_Business_Templates_Data.php:358
+msgid "Car / Vehicle Rental"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:357
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+msgid "Horizon Car Rentals"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:359
+msgid "Reserve your vehicle online in minutes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:362
+msgid "Economy & Compact"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:363
+msgid "SUVs & Vans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:367
+msgid "Economy Car (Daily)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:367
+msgid "Fuel-efficient compact car, perfect for city driving."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:368
+msgid "Midsize Sedan (Daily)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:368
+msgid "Comfortable midsize sedan with room for four passengers."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:369
+msgid "SUV (Daily)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:369
+msgid "Spacious SUV with extra cargo room, great for road trips."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:370
+msgid "Passenger Van (Daily)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:370
+msgid "Seats up to seven, ideal for group travel."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:371
+msgid "Luxury Sedan (Daily)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:371
+msgid "Premium sedan with leather interior for a comfortable ride."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:375
+msgid "Additional Driver"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:375
+msgid "Add a second authorized driver to your rental agreement."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:376
+msgid "GPS Navigation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:376
+msgid "In-car GPS unit for the length of your rental."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:377
+msgid "Child Safety Seat"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:377
+msgid "Rear-facing or booster child seat, installed for you."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:380
+msgid "Unlimited Mileage"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:381
+msgid "24/7 Roadside Assistance"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:382
+msgid "Free Cancellation up to 24 Hours"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:383
+msgid "Well-Maintained, Late-Model Fleet"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+msgid "makes booking a vehicle fast, transparent, and hassle-free."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+msgid "Choose a vehicle class."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+msgid "Pick your pickup and return dates."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:385
+msgid "Confirm and pick up your keys."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:386
+msgid "Every vehicle in our fleet is inspected and cleaned between rentals. Rates include unlimited mileage and roadside assistance for total peace of mind."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:388
+msgid "What do I need to rent a car?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:388
+msgid "A valid driver's license, a credit card in the renter's name, and proof of insurance if required."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:389
+msgid "Is there a mileage limit?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:389
+msgid "No, all rentals include unlimited mileage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:390
+msgid "Can I cancel my reservation?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:390
+msgid "Yes, cancellations made 24 hours in advance are fully refundable."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:391
+msgid "Do you offer one-way rentals?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:391
+msgid "Contact us directly to check one-way availability for your route."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:407
+msgid "Smooth pickup"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:407
+msgid "Car was ready and clean exactly when I arrived."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:408
+msgid "Good value SUV"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:408
+msgid "Plenty of room for our road trip. Would rent again."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:409
+#: Admin/data/MPWPB_Business_Templates_Data.php:1607
+msgid "Easy online booking"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:409
+msgid "Reserved in five minutes, no surprise fees at pickup."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:410
+msgid "Great customer service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:410
+msgid "Staff helped me swap vehicles last minute with no hassle."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:416
+#: Admin/data/MPWPB_Business_Templates_Data.php:421
+msgid "Spa, Massage & Beauty"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:420
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "Serenity Spa & Massage"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:422
+msgid "Relax and unwind -- book your treatment online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:425
+msgid "Massage Therapy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:426
+msgid "Facials & Body Treatments"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:430
+msgid "Swedish Massage (60 min)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:430
+msgid "Gentle, relaxing full-body massage to ease tension."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:431
+msgid "Deep Tissue Massage (60 min)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:431
+msgid "Firm-pressure massage targeting muscle tension and knots."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:432
+msgid "Hot Stone Massage (75 min)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:432
+msgid "Heated stones combined with massage for deep relaxation."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:433
+msgid "Classic Facial"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:433
+msgid "Cleanse, exfoliate, and hydrate for glowing skin."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:434
+msgid "Body Scrub & Wrap"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:434
+msgid "Full-body exfoliation followed by a hydrating wrap."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:438
+msgid "Aromatherapy Upgrade"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:438
+msgid "Choice of essential oil blend added to your treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:439
+msgid "Extra 15 Minutes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:439
+msgid "Extend any massage or treatment by 15 minutes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:440
+msgid "Paraffin Hand Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:440
+msgid "Warm paraffin dip to soften and soothe hands."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:443
+msgid "Certified Massage Therapists"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:444
+msgid "Organic Skincare Products"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:445
+msgid "Tranquil Private Treatment Rooms"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:446
+msgid "Complimentary Herbal Tea"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "offers a calm escape with therapeutic massage and skincare treatments."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "Choose a massage or treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "Pick your preferred therapist and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "Add any enhancements."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:448
+msgid "Arrive 10 minutes early to unwind before your session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:449
+msgid "All therapists are licensed and trained in a range of massage modalities. We use organic, cruelty-free products throughout every treatment room."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:451
+msgid "What should I wear during a massage?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:451
+msgid "You will be professionally draped throughout -- undress to your comfort level."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:452
+msgid "Can I request a specific therapist?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:452
+msgid "Yes, you can select your preferred therapist when booking."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:453
+msgid "Do you offer gift cards?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:453
+msgid "Yes, gift cards are available for any treatment or dollar amount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:454
+msgid "Is there a membership option?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:454
+msgid "Yes -- ask about our monthly spa membership with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:470
+msgid "So relaxing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:470
+msgid "The hot stone massage was exactly what I needed. Beautiful, calm space."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:471
+msgid "Great deep tissue"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:471
+msgid "Noah worked out weeks of tension from my shoulders."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:472
+msgid "Lovely facial"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:472
+msgid "My skin felt amazing afterward. Booking online was simple."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:473
+msgid "Worth the membership"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:473
+msgid "Signed up for the monthly plan after my first visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:479
+#: Admin/data/MPWPB_Business_Templates_Data.php:484
+msgid "Nail Salon"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:483
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+msgid "Polished Nail Studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:485
+msgid "Manicures and pedicures, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:488
+msgid "Manicures"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:489
+msgid "Pedicures"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:493
+msgid "Classic Manicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:493
+msgid "Shape, cuticle care, and polish of your choice."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:494
+msgid "Gel Manicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:494
+msgid "Long-lasting gel polish with a chip-resistant finish."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:495
+msgid "Acrylic Full Set"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:495
+msgid "Full set of acrylic extensions shaped and polished to your liking."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:496
+msgid "Classic Pedicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:496
+msgid "Soak, exfoliation, and polish for healthy, happy feet."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:497
+msgid "Deluxe Spa Pedicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:497
+msgid "Extended soak, callus treatment, massage, and polish."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:501
+msgid "Nail Art (per nail)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:501
+msgid "Custom hand-painted nail art design."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:502
+msgid "Paraffin Wax Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:502
+msgid "Warm paraffin dip for extra-soft hands or feet."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:503
+msgid "Polish Change Only"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:503
+msgid "Quick polish removal and reapplication."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:506
+msgid "Sterilized Tools for Every Client"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:507
+msgid "Wide Shade Selection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:508
+msgid "Walk-Ins Welcome"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:509
+msgid "Relaxing Massage Chairs"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+msgid "offers clean, relaxing manicures and pedicures for every occasion."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+msgid "Choose a manicure or pedicure service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "Pick a date and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+msgid "Add nail art or extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:511
+msgid "Confirm and relax in the chair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:512
+msgid "All tools are sanitized between every client using hospital-grade sterilization equipment. We stock a wide range of polish brands and shades."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:514
+msgid "How often are your tools sterilized?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:514
+msgid "All tools are sterilized after every single client using hospital-grade equipment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:515
+msgid "How long does gel polish last?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:515
+msgid "Gel manicures typically last two to three weeks without chipping."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:516
+msgid "Do you take walk-ins?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:516
+msgid "Yes, though booking online guarantees your preferred time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:517
+msgid "Can I bring my own nail design reference?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:517
+msgid "Of course -- feel free to bring photos or ideas for our nail artists."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:533
+msgid "Beautiful gel manicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:533
+msgid "Grace did an amazing job, still perfect three weeks later."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:534
+msgid "Relaxing pedicure"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:534
+msgid "The massage chairs are a nice touch. Will be back monthly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:535
+msgid "Great nail art"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:535
+msgid "Olivia nailed the design I brought in on my phone."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:536
+msgid "Very clean salon"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:536
+msgid "You can tell hygiene is taken seriously here."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:542
+#: Admin/data/MPWPB_Business_Templates_Data.php:547
+msgid "Dental Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:546
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+msgid "Brightside Dental Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:548
+msgid "Gentle, modern dental care -- book online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:551
+msgid "General Dentistry"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:552
+msgid "Cosmetic & Restorative"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:556
+msgid "Dental Check-Up & Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:556
+msgid "Routine exam, professional cleaning, and cavity check."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:557
+msgid "Cavity Filling"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:557
+msgid "Tooth-colored composite filling for a single cavity."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:558
+msgid "Tooth Extraction"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:558
+msgid "Simple extraction performed under local anesthetic."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:559
+msgid "Teeth Whitening"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:559
+msgid "In-office professional whitening for a brighter smile."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:560
+msgid "Dental Crown Fitting"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:560
+msgid "Custom crown fitting to restore a damaged tooth."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:564
+msgid "Digital X-Ray"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:564
+msgid "Low-radiation digital X-ray for diagnostics."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:565
+msgid "Fluoride Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:565
+msgid "Protective fluoride application to strengthen enamel."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:566
+msgid "Emergency Consultation Fee"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:566
+msgid "Priority same-day consultation for dental emergencies."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:569
+msgid "Board-Certified Dentists"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:570
+msgid "Modern Digital X-Ray Equipment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:571
+msgid "Gentle Care for Anxious Patients"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:572
+msgid "Flexible Payment Plans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+msgid "provides gentle, modern dental care for the whole family."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+msgid "Choose a checkup or treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+msgid "Add any extras like X-rays."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:574
+msgid "Confirm and arrive 10 minutes early."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:575
+msgid "Our dentists focus on comfortable, low-anxiety visits with modern digital imaging and clear treatment explanations at every step."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:577
+msgid "Do you treat nervous or anxious patients?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:577
+msgid "Yes, our team specializes in gentle, calming care for anxious patients."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:578
+msgid "Do you accept dental insurance?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:578
+msgid "We accept most major dental insurance plans and offer payment plans as well."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:579
+msgid "How often should I get a cleaning?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:579
+msgid "We recommend a check-up and cleaning every six months."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:580
+msgid "Do you handle dental emergencies?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:580
+msgid "Yes, book an emergency consultation and we will see you the same day when possible."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:596
+msgid "Painless visit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:596
+msgid "Emily made my filling completely painless. Highly recommend."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:597
+msgid "Great with anxious patients"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:597
+msgid "I hate the dentist but this team made it easy."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:598
+msgid "Nice whitening results"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:598
+msgid "Noticeable difference after one session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:599
+msgid "Fast emergency visit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:599
+msgid "Called with a broken tooth and was seen within hours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:605
+#: Admin/data/MPWPB_Business_Templates_Data.php:610
+msgid "Physiotherapy Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:609
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "MoveWell Physiotherapy Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:611
+msgid "Recover and move better -- book your session online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:614
+msgid "Assessment & Consultation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:615
+msgid "Treatment Sessions"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:619
+msgid "Initial Assessment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:619
+msgid "Full movement assessment and personalized recovery plan."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:620
+msgid "Follow-Up Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:620
+msgid "Progress check and treatment plan adjustment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:621
+msgid "Sports Injury Rehab Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:621
+msgid "Hands-on rehab for sprains, strains, and sports injuries."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:622
+msgid "Post-Surgery Rehabilitation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:622
+msgid "Guided rehabilitation to restore strength and mobility after surgery."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:623
+msgid "Manual Therapy & Stretching"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:623
+msgid "Hands-on manual therapy to relieve pain and improve mobility."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:627
+msgid "Take-Home Exercise Kit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:627
+msgid "Resistance bands and a printed exercise plan."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:628
+msgid "Kinesiology Taping"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:628
+msgid "Supportive taping applied to an injured area."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:629
+msgid "Extended Session (+15 min)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:629
+msgid "Add 15 minutes of extra treatment time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:632
+msgid "Licensed Physiotherapists"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:633
+msgid "Personalized Recovery Plans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:634
+msgid "Modern Rehab Equipment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:635
+msgid "Insurance Receipts Provided"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "helps you recover from injury and move with confidence again."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "Book an assessment or follow-up session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "Choose a date and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "Add any take-home extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:637
+msgid "Confirm and start your recovery plan."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:638
+msgid "Our physiotherapists create individualized rehab plans for sports injuries, post-surgical recovery, and chronic pain, using modern equipment and manual therapy."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:640
+msgid "Do I need a referral to book?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:640
+msgid "No referral is required, though we can work alongside your physician's recommendations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:641
+msgid "How many sessions will I need?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:641
+msgid "This varies by injury -- your therapist will outline a plan after your initial assessment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:642
+msgid "Do you provide receipts for insurance?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:642
+msgid "Yes, detailed receipts are provided for extended health insurance claims."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:643
+msgid "Is there a discount for a recurring treatment plan?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:643
+msgid "Yes -- ask about our weekly recurring session plan with a booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:659
+msgid "Back to running"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:659
+msgid "Hannah got me back to running after my knee injury. Amazing care."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:660
+msgid "Great post-surgery support"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:660
+msgid "Lucas was patient and encouraging through my whole recovery."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:661
+msgid "Effective treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:661
+msgid "My back pain improved significantly after a few sessions."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:662
+msgid "Highly professional"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:662
+msgid "Clear explanations and a real plan, not just generic exercises."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:668
+#: Admin/data/MPWPB_Business_Templates_Data.php:673
+msgid "Chiropractic Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:672
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+msgid "Align Chiropractic Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:674
+msgid "Spinal health and pain relief -- book online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:677
+msgid "Consultations"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:678
+msgid "Adjustments & Therapy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:682
+msgid "Full history, posture assessment, and treatment plan."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:683
+msgid "Follow-Up Adjustment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:683
+msgid "Quick follow-up spinal adjustment for existing patients."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:684
+msgid "Spinal Adjustment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:684
+msgid "Hands-on spinal adjustment to relieve pain and improve alignment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:685
+msgid "Therapeutic Massage Add-On Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:685
+msgid "Muscle-relaxing massage paired with your adjustment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:686
+msgid "Posture & Mobility Assessment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:686
+msgid "Detailed posture and mobility screening with recommendations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:690
+msgid "Heat Therapy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:690
+msgid "Heat pack applied before or after your adjustment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:691
+msgid "Cold Laser Therapy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:691
+msgid "Low-level laser therapy to reduce inflammation."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:692
+msgid "Take-Home Posture Brace"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:692
+msgid "Supportive brace to reinforce posture between visits."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:695
+msgid "Licensed Chiropractors"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:696
+msgid "Personalized Treatment Plans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:698
+msgid "Family-Friendly Clinic"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+msgid "helps patients of all ages find lasting relief from pain and stiffness."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+msgid "Book a consultation or adjustment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+msgid "Add any therapy extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:700
+msgid "Confirm and start feeling better."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:701
+msgid "Our chiropractors use evidence-based techniques tailored to each patient, with ongoing care plans for lasting results."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:703
+msgid "Is chiropractic treatment safe?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:703
+msgid "Yes, all adjustments are performed by licensed chiropractors using safe, proven techniques."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:704
+msgid "How many visits will I need?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:704
+msgid "Your chiropractor will recommend a plan based on your condition during your first visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:705
+msgid "Do you treat children?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:705
+msgid "Yes, we welcome patients of all ages with age-appropriate techniques."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:706
+msgid "Is there a discount for ongoing care?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:706
+msgid "Yes -- ask about our weekly recurring care plan with a booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:722
+msgid "No more back pain"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:722
+msgid "After years of back pain, Ethan finally got me real relief."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:723
+msgid "Great with kids"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:723
+msgid "Sophie was wonderful adjusting my daughter after her sports injury."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:724
+msgid "Solid results"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:724
+msgid "Noticeable improvement in my posture after a month of visits."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:725
+msgid "Friendly and professional"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:725
+msgid "The whole team makes every visit easy and comfortable."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:731
+#: Admin/data/MPWPB_Business_Templates_Data.php:736
+msgid "Fitness Training & Gym Sessions"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:735
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+msgid "Ironclad Fitness Studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:737
+msgid "Personal training and group classes -- book your spot"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:740
+msgid "Personal Training"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:741
+msgid "Group Classes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:745
+msgid "Initial Fitness Assessment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:745
+msgid "Baseline fitness testing and goal-setting session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:746
+msgid "1-on-1 Personal Training Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:746
+msgid "Customized one-on-one strength and conditioning session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:747
+msgid "Nutrition Coaching Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:747
+msgid "Personalized nutrition guidance to support your training goals."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:748
+msgid "HIIT Group Class"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:748
+msgid "High-intensity interval training in a motivating group setting."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:749
+msgid "Strength & Conditioning Class"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:749
+msgid "Group strength training class for all fitness levels."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:753
+msgid "Extra Guest Pass"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:753
+msgid "Bring a friend to your next group class."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:754
+msgid "Body Composition Scan"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:754
+msgid "Detailed body composition analysis and progress tracking."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:755
+msgid "Personal Training Add-On (30 min)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:755
+msgid "Extend any personal training session by 30 minutes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:758
+msgid "Certified Personal Trainers"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:759
+msgid "Small Group Class Sizes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:760
+msgid "Modern Equipment & Free Weights"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:761
+msgid "Flexible Membership Options"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+msgid "combines personal training and group classes to help you reach your goals."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+msgid "Choose a training session or class."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:763
+msgid "Confirm and show up ready to train."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:764
+msgid "Our certified trainers build personalized programs for every fitness level, backed by a full schedule of high-energy group classes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:766
+msgid "Do I need experience to join a group class?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:766
+msgid "No, all classes are designed to accommodate every fitness level."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:767
+msgid "What should I bring to my first session?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:767
+msgid "Comfortable workout clothes, athletic shoes, and a water bottle."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:768
+msgid "Can I freeze my membership?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:768
+msgid "Yes, memberships can be paused for up to 30 days per year."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:769
+msgid "Is there a discount for a monthly plan?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:769
+msgid "Yes -- ask about our monthly membership with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:785
+msgid "Best trainer ever"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:785
+msgid "Derek pushed me exactly the right amount every session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:786
+msgid "Love the HIIT classes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:786
+msgid "Naomi runs a fun, high-energy class every time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:787
+msgid "Great equipment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:787
+msgid "Gym is always clean and well-stocked with weights."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:788
+msgid "Membership is worth it"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:788
+msgid "Signed up for the monthly plan and love the flexibility."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:794
+#: Admin/data/MPWPB_Business_Templates_Data.php:799
+msgid "Yoga & Wellness Classes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:798
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+msgid "Lotus Yoga & Wellness Studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:800
+msgid "Find your balance -- book a class or private session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:803
+msgid "Yoga Classes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:804
+msgid "Private & Wellness Sessions"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:808
+msgid "Beginner Yoga Class"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:808
+msgid "Gentle introduction to foundational yoga poses and breathing."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:809
+msgid "Vinyasa Flow Class"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:809
+msgid "Dynamic, flowing sequence linking breath and movement."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:810
+msgid "Restorative Yoga Class"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:810
+msgid "Slow, supported poses designed for deep relaxation."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:811
+msgid "Private Yoga Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:811
+msgid "One-on-one session tailored to your goals and experience level."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:812
+msgid "Meditation & Breathwork Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:812
+msgid "Guided meditation and breathing techniques to reduce stress."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:816
+msgid "Mat Rental"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:816
+msgid "Clean yoga mat provided for your class."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:817
+msgid "Extra 15 Minutes (Private Session)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:817
+msgid "Extend your private session by 15 minutes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:818
+msgid "Essential Oil Aromatherapy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:818
+msgid "Calming essential oil blend added to your session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:821
+msgid "Certified Yoga Instructors"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:822
+msgid "All Levels Welcome"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:823
+msgid "Calming Studio Atmosphere"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:824
+msgid "Mats & Props Provided"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+msgid "offers classes and private sessions for every level of practice."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+msgid "Choose a class or private session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:826
+msgid "Confirm and arrive a few minutes early to settle in."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:827
+msgid "Our certified instructors teach a range of styles from gentle restorative to dynamic vinyasa flow, in a calm, welcoming studio space."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:829
+msgid "Do I need to bring my own mat?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:829
+msgid "No, mats and props are provided, or you can rent one for a small fee."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:830
+msgid "Are classes suitable for beginners?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:830
+msgid "Yes, we offer beginner-friendly classes and instructors provide modifications for every level."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:831
+msgid "Can I book a private session for two people?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:831
+msgid "Yes, contact us to arrange a private session for couples or small groups."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:832
+msgid "Is there a membership discount?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:832
+msgid "Yes -- ask about our weekly class membership with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:848
+msgid "Perfect for beginners"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:848
+msgid "Maya made me feel comfortable from my very first class."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:849
+msgid "Love the vinyasa flow"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:849
+msgid "Liam's class is challenging and energizing every time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:850
+msgid "Calming studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:850
+msgid "Such a peaceful space. The restorative class is my favorite."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:851
+msgid "Great private session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:851
+msgid "Booked a private session for my bad back and felt so much better."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:857
+#: Admin/data/MPWPB_Business_Templates_Data.php:862
+msgid "Photography Studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:861
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+msgid "Aperture Photography Studio"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:863
+msgid "Portraits and events, captured beautifully"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:866
+msgid "Portrait Sessions"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:867
+msgid "Event Photography"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:871
+msgid "Individual Portrait Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:871
+msgid "Studio or outdoor portrait session with edited digital photos."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:872
+msgid "Family Portrait Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:872
+msgid "Relaxed family session with multiple edited images."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:873
+msgid "Headshot Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:873
+msgid "Professional headshots for business or personal branding."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:874
+msgid "Event Photography (Half Day)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:874
+msgid "Four hours of event coverage with edited highlights."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:875
+msgid "Event Photography (Full Day)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:875
+msgid "Full-day event coverage with a complete edited gallery."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:879
+msgid "Extra Edited Photos (10)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:879
+msgid "Ten additional professionally edited photos."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:880
+msgid "Rush Delivery (48h)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:880
+msgid "Receive your edited photos within 48 hours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:881
+msgid "Printed Photo Album"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:881
+msgid "Professionally printed and bound photo album."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:884
+msgid "Professional-Grade Equipment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:885
+msgid "Fast Digital Delivery"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:886
+msgid "Custom Editing Included"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:887
+msgid "Flexible Outdoor or Studio Locations"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+msgid "captures portraits and events with a natural, timeless style."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+msgid "Choose a portrait or event package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+msgid "Pick a date, time, and location."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:889
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+msgid "Confirm and we will handle the rest."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:890
+msgid "Every session includes professional editing and fast digital delivery, with printed products available on request."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:892
+msgid "How long until I receive my photos?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:892
+msgid "Standard delivery is 1-2 weeks; rush delivery is available as an add-on."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:893
+msgid "Can sessions be held outdoors?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:893
+msgid "Yes, we offer both studio and outdoor location sessions."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:894
+msgid "How many edited photos do I receive?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:894
+msgid "Package details are confirmed at booking, with extra edited photos available as an add-on."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:895
+#: Admin/data/MPWPB_Business_Templates_Data.php:958
+msgid "Do you travel for events?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:895
+msgid "Yes, contact us for travel availability outside our local area."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:911
+msgid "Beautiful family photos"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:911
+msgid "Ava made our kids laugh and the photos turned out perfect."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:912
+msgid "Great headshots"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:912
+msgid "Jasper delivered professional headshots fast for my new job."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:913
+msgid "Lovely event coverage"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:913
+msgid "Captured all the important moments at our anniversary party."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:914
+msgid "Worth every penny"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:914
+msgid "The edited gallery exceeded our expectations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:920
+#: Admin/data/MPWPB_Business_Templates_Data.php:925
+msgid "Videography Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:924
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+msgid "Frame & Motion Videography"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:926
+msgid "Cinematic video for your events and brand"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:929
+msgid "Event Videography"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:930
+msgid "Editing & Production"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:934
+msgid "Event Videography (Half Day)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:934
+msgid "Four hours of professional event video coverage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:935
+msgid "Event Videography (Full Day)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:935
+msgid "Full-day coverage with a complete edited film."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:936
+msgid "Highlight Reel Add-On"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:936
+msgid "Short, shareable highlight reel edited from your footage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:937
+msgid "Video Editing Package"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:937
+msgid "Professional editing of your own raw footage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:938
+msgid "Drone Aerial Footage"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:938
+msgid "Licensed drone operator capturing aerial video footage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:942
+msgid "Extra Camera Angle"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:942
+msgid "Add a second camera operator for multi-angle coverage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:943
+msgid "Same-Week Delivery"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:943
+msgid "Receive your final edited video within the same week."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:944
+msgid "Raw Footage Copy"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:944
+msgid "Receive a copy of the unedited raw footage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:947
+msgid "Multi-Camera Setup Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:948
+msgid "Cinematic Editing Style"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:949
+msgid "Drone Footage on Request"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:950
+msgid "Fast Turnaround Times"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+msgid "creates cinematic video coverage for events and brands alike."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+msgid "Choose a coverage package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "Pick your event date and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:952
+msgid "Confirm and we will be there to film."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:953
+msgid "Our videographers use professional multi-camera setups and cinematic editing to deliver polished, story-driven video."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:955
+msgid "How long until I receive my video?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:955
+msgid "Standard delivery is 2-3 weeks; same-week delivery is available as an add-on."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:956
+msgid "Do you offer drone footage?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:956
+msgid "Yes, licensed drone footage can be added to any package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:957
+msgid "Can I get the raw, unedited footage?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:957
+msgid "Yes, add the raw footage copy add-on to receive all original files."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:958
+msgid "Yes, contact us to confirm travel availability for your event location."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:974
+msgid "Stunning wedding video"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:974
+msgid "Owen captured every important moment beautifully."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:975
+msgid "Great corporate video"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:975
+msgid "Mia delivered a polished brand video ahead of schedule."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:976
+msgid "Impressive drone shots"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:976
+msgid "The aerial footage added a lot to our event video."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:977
+msgid "Fast turnaround"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:977
+msgid "Had our highlight reel back within a week, great quality."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:983
+#: Admin/data/MPWPB_Business_Templates_Data.php:988
+msgid "Home Cleaning Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:987
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+msgid "Sparkle & Shine Home Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:989
+msgid "A cleaner home, booked in minutes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:992
+msgid "Standard Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:993
+msgid "Deep & Specialty Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:997
+msgid "Standard Cleaning (1-2 Bed)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:997
+msgid "Dusting, vacuuming, mopping, and bathroom/kitchen cleaning."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:998
+msgid "Standard Cleaning (3-4 Bed)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:998
+msgid "Full-home standard cleaning for larger homes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:999
+msgid "Deep Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:999
+msgid "Detailed top-to-bottom clean including baseboards and inside appliances."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1000
+msgid "Move-In / Move-Out Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1000
+msgid "Thorough cleaning for an empty home before or after a move."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1001
+msgid "Post-Construction Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1001
+msgid "Removal of dust and debris after renovation or construction work."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1005
+msgid "Inside Oven Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1005
+msgid "Deep clean of the interior of your oven."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1006
+msgid "Inside Fridge Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1006
+msgid "Full interior clean of your refrigerator."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1007
+msgid "Interior Window Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1007
+msgid "Streak-free cleaning of interior window glass."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1010
+msgid "Insured & Background-Checked Cleaners"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1012
+#: Admin/data/MPWPB_Business_Templates_Data.php:1138
+msgid "Satisfaction Guarantee"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1013
+msgid "Flexible Scheduling"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+msgid "gives you back your weekend with reliable, thorough home cleaning."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "Choose a cleaning package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "Add any specialty extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1015
+msgid "Confirm and let us handle the rest."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1016
+msgid "All cleaners are insured, background-checked, and trained on eco-friendly cleaning methods that are safe for kids and pets."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1018
+msgid "Do I need to provide cleaning supplies?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1018
+msgid "No, our cleaners bring all eco-friendly supplies and equipment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1019
+msgid "Do I need to be home during the cleaning?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1019
+msgid "No, many customers provide access instructions and are not home during the visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1020
+msgid "What if I am not satisfied with the cleaning?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1020
+msgid "Contact us within 24 hours and we will return to make it right, free of charge."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1021
+msgid "Can I set up recurring cleanings?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1021
+#: Admin/data/MPWPB_Business_Templates_Data.php:1459
+msgid "Yes -- weekly, bi-weekly, and monthly recurring plans are available with a discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1037
+msgid "Spotless every time"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1037
+msgid "Isla is thorough and always leaves the house sparkling."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1038
+msgid "Great move-out clean"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1038
+msgid "Got our full deposit back thanks to Diego's deep clean."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1039
+msgid "Reliable weekly service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1039
+msgid "Been on the weekly plan for months, always consistent."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1040
+msgid "Easy to book"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1040
+msgid "Online booking was simple and the team showed up on time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1046
+#: Admin/data/MPWPB_Business_Templates_Data.php:1051
+msgid "Office Cleaning Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1050
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "CrystalClear Office Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1052
+msgid "A cleaner workplace, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1055
+msgid "Routine Office Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1056
+msgid "Specialty & One-Time Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1060
+msgid "Small Office Cleaning (Up to 1,500 sq ft)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1060
+msgid "Routine cleaning of desks, floors, and common areas."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1061
+msgid "Large Office Cleaning (1,500+ sq ft)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1061
+msgid "Full-floor cleaning for larger office spaces."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1062
+msgid "Sanitization & Disinfection Service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1062
+msgid "Hospital-grade disinfection of high-touch surfaces."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1063
+msgid "Carpet & Upholstery Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1063
+msgid "Deep steam cleaning of carpets and office furniture."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1064
+msgid "Post-Event Office Cleanup"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1064
+msgid "Full cleanup after an office event or gathering."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1068
+msgid "Restroom Deep Sanitize"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1068
+msgid "Intensive sanitizing of restroom fixtures and surfaces."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1069
+msgid "Break Room Deep Clean"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1069
+msgid "Deep clean of break room appliances and surfaces."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1070
+msgid "After-Hours Service Fee"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1070
+msgid "Priority scheduling for evening or overnight cleaning."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1073
+msgid "Flexible After-Hours Scheduling"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1074
+msgid "Fully Insured Cleaning Crews"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1075
+msgid "Commercial-Grade Equipment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1076
+msgid "Custom Cleaning Checklists"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "keeps your workplace clean, sanitized, and presentable for staff and clients."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "Pick a date and time, including after-hours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1078
+msgid "Confirm and we will take care of the rest."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1079
+msgid "Our fully insured crews use commercial-grade equipment and follow a custom checklist built around your office's specific needs."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1081
+msgid "Can you clean after business hours?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1081
+msgid "Yes, evening and early-morning cleaning is available for an additional fee."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1082
+msgid "Are your cleaners insured?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1082
+msgid "Yes, all cleaning crews are fully insured and background-checked."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1083
+msgid "Can we set up a recurring cleaning schedule?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1083
+msgid "Yes -- weekly and monthly recurring plans are available with a discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1084
+msgid "Do you bring your own equipment?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1084
+msgid "Yes, our crews arrive fully equipped with commercial-grade supplies."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1100
+msgid "Reliable and thorough"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1100
+msgid "Victor's crew never misses a spot in our office."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1101
+msgid "Great after-hours service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1101
+msgid "They clean overnight so there is zero disruption to our staff."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1102
+msgid "Good carpet cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1102
+msgid "Our office carpets look brand new after the deep clean."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1103
+msgid "Professional team"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1103
+msgid "Lena is always responsive and the crew is very professional."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1109
+#: Admin/data/MPWPB_Business_Templates_Data.php:1114
+msgid "Pest Control Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1113
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+msgid "ShieldGuard Pest Control"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1115
+msgid "Pest-free homes, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1118
+#: Admin/data/MPWPB_Business_Templates_Data.php:1307
+msgid "Inspections"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1119
+msgid "Treatment Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1123
+msgid "Pest Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1123
+msgid "Full property inspection to identify pest activity and entry points."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1124
+msgid "Termite Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1124
+msgid "Detailed termite inspection with a written report."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1125
+msgid "General Pest Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1125
+msgid "Treatment for common household pests including ants and spiders."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1126
+msgid "Rodent Control Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1126
+msgid "Trapping and exclusion treatment for rodent activity."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1127
+msgid "Termite Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1127
+msgid "Targeted termite treatment to eliminate colonies and prevent damage."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1131
+msgid "Follow-Up Treatment Visit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1131
+msgid "Additional treatment visit to confirm pests are gone."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1132
+msgid "Outdoor Perimeter Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1132
+msgid "Protective treatment around the exterior of your property."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1133
+msgid "Attic Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1133
+msgid "Check the attic for nesting or entry points."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1136
+msgid "Licensed Pest Control Technicians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1137
+msgid "Pet & Family-Safe Treatments"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+msgid "protects your home from pests using safe, effective treatments."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+msgid "Choose an inspection or treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1141
+msgid "Add any follow-up services."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1142
+msgid "Our licensed technicians use pet- and family-safe products, with every treatment backed by a satisfaction guarantee."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1144
+msgid "Are your treatments safe for pets and children?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1144
+msgid "Yes, we use family- and pet-safe products for all standard treatments."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1145
+msgid "How soon can you come out?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1145
+msgid "We typically offer appointments within the same week."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1146
+msgid "Do you offer ongoing pest prevention plans?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1146
+msgid "Yes -- ask about our monthly prevention plan with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1147
+msgid "What if pests come back after treatment?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1147
+msgid "We offer a free follow-up visit if pests return within 30 days."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1163
+msgid "Ants are gone"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1163
+msgid "Nathan solved our ant problem in one visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1164
+msgid "Very thorough inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1164
+msgid "Grace explained everything clearly and treated every entry point."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1165
+msgid "Effective termite treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1165
+msgid "No more termite activity since the treatment."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1166
+msgid "Safe for our pets"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1166
+msgid "Glad to know the treatment was safe to use around our dog."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1172
+#: Admin/data/MPWPB_Business_Templates_Data.php:1177
+msgid "Appliance & Electronics Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1176
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+msgid "FixIt Appliance Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1178
+msgid "Fast, upfront-priced appliance repairs"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1181
+msgid "Diagnostics"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1182
+msgid "Repair Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1186
+msgid "Appliance Diagnostic Visit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1186
+msgid "On-site diagnostic to identify the issue and repair cost."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1187
+msgid "Refrigerator Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1187
+msgid "Diagnosis and repair of cooling, leaking, or noise issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1188
+msgid "Washer/Dryer Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1188
+msgid "Repair for washers or dryers not spinning, draining, or heating."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1189
+msgid "Dishwasher Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1189
+msgid "Repair for leaks, drainage issues, or dishwashers that won't start."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1190
+msgid "Oven & Stove Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1190
+msgid "Repair for ovens and stovetops not heating correctly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1194
+msgid "Emergency Same-Day Service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1194
+msgid "Priority same-day appointment for urgent repairs."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1195
+msgid "Replacement Part Sourcing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1195
+msgid "Sourcing of hard-to-find replacement parts."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1196
+msgid "Extended Warranty (90 Days)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1196
+msgid "Extend your repair warranty coverage to 90 days."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1199
+msgid "Certified Appliance Technicians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1200
+msgid "Most Major Brands Serviced"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1201
+#: Admin/data/MPWPB_Business_Templates_Data.php:1389
+msgid "Upfront Flat-Rate Pricing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1202
+msgid "90-Day Repair Warranty"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+msgid "gets your household appliances running again, fast and affordably."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1204
+msgid "Confirm and we will come to you."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1205
+msgid "Our certified technicians service most major appliance brands, with upfront flat-rate pricing and a 90-day workmanship warranty."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1207
+msgid "Do you charge for the diagnostic visit?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1207
+msgid "The diagnostic fee is waived if you proceed with the repair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1208
+msgid "Which brands do you service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1208
+msgid "We service most major appliance brands -- contact us to confirm yours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1209
+msgid "Yes, all repairs include a standard 30-day warranty, extendable to 90 days."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1210
+msgid "Can I get same-day service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1210
+msgid "Yes, add the emergency same-day service option when booking."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1226
+msgid "Fixed my fridge fast"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1226
+msgid "Trevor diagnosed and fixed the issue in under an hour."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1227
+msgid "Upfront pricing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1227
+msgid "No surprise charges, exactly the quoted price."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1228
+msgid "Good dishwasher repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1228
+msgid "Melissa was friendly and explained the issue clearly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1229
+msgid "Same-day service saved us"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1229
+msgid "Oven was fixed the same day we called, great service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1235
+#: Admin/data/MPWPB_Business_Templates_Data.php:1240
+msgid "Plumbing Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1239
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+msgid "FlowRight Plumbing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1241
+msgid "Reliable plumbing repairs, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1244
+msgid "Inspections & Diagnostics"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1245
+#: Admin/data/MPWPB_Business_Templates_Data.php:1371
+msgid "Repair & Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1249
+msgid "Plumbing Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1249
+msgid "Full inspection of pipes, fixtures, and water pressure."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1250
+msgid "Drain Cleaning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1250
+msgid "Clearing of clogged or slow-draining pipes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1251
+msgid "Leak Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1251
+msgid "Detection and repair of pipe or fixture leaks."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1252
+msgid "Water Heater Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1252
+msgid "Removal of old unit and installation of a new water heater."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1253
+msgid "Faucet & Fixture Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1253
+msgid "Installation of new faucets, sinks, or fixtures."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1257
+#: Admin/data/MPWPB_Business_Templates_Data.php:1320
+#: Admin/data/MPWPB_Business_Templates_Data.php:1383
+msgid "Emergency Call-Out Fee"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1257
+msgid "Priority emergency dispatch outside normal hours."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1258
+msgid "Camera Drain Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1258
+msgid "Video camera inspection to locate hidden pipe issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1259
+msgid "Pipe Insulation Add-On"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1259
+msgid "Insulation added to exposed pipes to prevent freezing."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1262
+msgid "Licensed & Insured Plumbers"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1263
+msgid "24/7 Emergency Service Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1264
+msgid "Upfront Pricing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1265
+msgid "Fully Stocked Service Vehicles"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+msgid "handles everything from small leaks to full water heater installations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+msgid "Choose an inspection or repair service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1267
+msgid "Confirm and we will be on our way."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1268
+msgid "Our licensed plumbers arrive in fully stocked vehicles ready to resolve most issues in a single visit, with transparent upfront pricing."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1270
+msgid "Do you offer emergency plumbing service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1270
+msgid "Yes, we offer 24/7 emergency call-outs for urgent plumbing issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1271
+msgid "Is pricing given upfront?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1271
+msgid "Yes, you will receive a clear price before any work begins."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1272
+msgid "Do you offer an annual maintenance plan?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1272
+#: Admin/data/MPWPB_Business_Templates_Data.php:1398
+msgid "Yes -- ask about our monthly maintenance plan with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1273
+msgid "Are your plumbers licensed?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1273
+msgid "Yes, all our plumbers are fully licensed and insured."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1289
+msgid "Fixed our leak fast"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1289
+msgid "Sean found and fixed the leak within the hour."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1290
+#: Admin/data/MPWPB_Business_Templates_Data.php:1544
+msgid "Great weekend availability"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1290
+msgid "So glad they could come out on a Sunday for our emergency."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1291
+msgid "Solid water heater install"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1291
+msgid "Dominic was efficient and cleaned up afterward."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1292
+msgid "Transparent pricing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1292
+msgid "Quoted the price upfront with no surprises on the bill."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1298
+#: Admin/data/MPWPB_Business_Templates_Data.php:1303
+msgid "Electrical Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1302
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+msgid "BrightWire Electrical Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1304
+msgid "Licensed electrical work, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1308
+msgid "Repairs & Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1312
+msgid "Electrical Safety Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1312
+msgid "Full inspection of wiring, panel, and outlets for safety issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1313
+msgid "Outlet & Switch Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1313
+msgid "Installation or replacement of outlets and switches."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1314
+msgid "Circuit Breaker Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1314
+msgid "Diagnosis and repair of tripped or faulty circuit breakers."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1315
+msgid "Lighting Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1315
+msgid "Installation of new light fixtures, indoor or outdoor."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1316
+msgid "Whole-Home Rewiring Estimate Visit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1316
+msgid "On-site assessment and quote for a full home rewiring project."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1320
+msgid "Priority emergency electrical dispatch."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1321
+msgid "Smart Home Device Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1321
+msgid "Installation of smart switches, plugs, or thermostats."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1322
+msgid "Surge Protector Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1322
+msgid "Whole-home surge protection installed at your panel."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1325
+msgid "Licensed Electricians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1326
+msgid "Up-to-Code Guaranteed Work"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1327
+msgid "Free Written Estimates"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1328
+#: Admin/data/MPWPB_Business_Templates_Data.php:1390
+msgid "Emergency Service Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1330
+msgid "handles residential electrical work safely and up to code."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1331
+msgid "All work is performed by licensed electricians and guaranteed to meet local code, with free written estimates for larger projects."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1333
+msgid "Are your electricians licensed?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1333
+msgid "Yes, all work is performed by fully licensed and insured electricians."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1334
+msgid "Do you offer emergency service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1334
+msgid "Yes, emergency call-outs are available for urgent electrical issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1335
+msgid "Can I get a free estimate for rewiring?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1335
+msgid "Yes, book an estimate visit and we will provide a written quote."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1336
+msgid "Do you install smart home devices?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1336
+msgid "Yes, add the smart home device installation extra to any visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1352
+msgid "Fixed our breaker fast"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1352
+msgid "Caleb diagnosed the tripping breaker in minutes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1353
+msgid "Great lighting install"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1353
+msgid "Vanessa installed our new fixtures perfectly and on time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1354
+msgid "Thorough inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1354
+msgid "Found an issue we did not know about and fixed it right away."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1355
+#: Admin/data/MPWPB_Business_Templates_Data.php:1481
+msgid "Fair pricing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1355
+msgid "Got a written estimate and the final bill matched exactly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1361
+#: Admin/data/MPWPB_Business_Templates_Data.php:1366
+msgid "HVAC Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1365
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+msgid "ComfortZone HVAC Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1367
+msgid "Heating and cooling repair, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1370
+msgid "Inspections & Tune-Ups"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1375
+msgid "HVAC System Inspection"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1375
+msgid "Full inspection of your heating and cooling system."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1376
+msgid "Seasonal Tune-Up"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1376
+msgid "Seasonal maintenance to keep your system running efficiently."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1377
+msgid "AC Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1377
+msgid "Diagnosis and repair of air conditioning issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1378
+msgid "Furnace Repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1378
+msgid "Diagnosis and repair of furnace heating issues."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1379
+msgid "New System Installation Estimate"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1379
+msgid "On-site assessment and quote for a new HVAC system."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1383
+msgid "Priority emergency dispatch for no-heat or no-cool situations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1384
+msgid "Fresh air filter installed for better airflow and air quality."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1385
+msgid "Duct Cleaning Add-On"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1385
+msgid "Cleaning of ductwork to improve airflow and air quality."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1388
+msgid "NATE-Certified Technicians"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1391
+msgid "All Major Brands Serviced"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1393
+msgid "keeps your home comfortable year-round with expert heating and cooling service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1394
+msgid "Our NATE-certified technicians service all major HVAC brands, with upfront flat-rate pricing and emergency availability for no-heat or no-cool emergencies."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1396
+msgid "How often should I service my HVAC system?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1396
+msgid "We recommend a seasonal tune-up twice a year, before summer and winter."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1397
+msgid "Do you offer emergency no-heat service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1397
+msgid "Yes, emergency call-outs are available for no-heat or no-cool situations."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1398
+msgid "Is there a maintenance plan available?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1399
+msgid "Do you service all HVAC brands?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1399
+msgid "Yes, our technicians are trained on all major heating and cooling brands."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1415
+msgid "AC fixed same day"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1415
+msgid "Miles came out in the middle of a heat wave and fixed our AC fast."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1416
+msgid "Great seasonal tune-up"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1416
+msgid "Renata caught a small issue before it became a big repair."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1417
+msgid "Solid furnace repair"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1417
+msgid "Heat is back on and running smoothly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1418
+msgid "Worth the maintenance plan"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1418
+msgid "Signed up for the monthly plan after our first tune-up."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1424
+#: Admin/data/MPWPB_Business_Templates_Data.php:1429
+msgid "Landscaping & Gardening"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1428
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+msgid "GreenScape Landscaping"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1430
+msgid "A beautiful yard, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1433
+msgid "Lawn Care"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1434
+msgid "Garden & Outdoor Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1438
+msgid "Lawn Mowing & Edging"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1438
+msgid "Mowing, edging, and cleanup for a well-kept lawn."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1439
+msgid "Lawn Fertilization Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1439
+msgid "Seasonal fertilization to keep your lawn healthy and green."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1440
+msgid "Garden Bed Design & Planting"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1440
+msgid "Custom garden bed design with planting included."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1441
+msgid "Hedge & Tree Trimming"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1441
+msgid "Shaping and trimming of hedges and small trees."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1442
+msgid "Mulching Service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1442
+msgid "Fresh mulch applied to garden beds for a clean, finished look."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1446
+msgid "Leaf Removal Add-On"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1446
+msgid "Full yard leaf removal and bagging."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1447
+msgid "Irrigation System Check"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1447
+msgid "Inspection and adjustment of your sprinkler system."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1448
+msgid "Weed Control Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1448
+msgid "Targeted treatment to control weeds in your lawn or beds."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1451
+msgid "Experienced Landscaping Crews"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1452
+msgid "Seasonal Maintenance Plans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1453
+msgid "Eco-Friendly Treatment Options"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1454
+msgid "Free On-Site Estimates"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+msgid "keeps your lawn and garden looking their best all year long."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+msgid "Choose a lawn or garden service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1456
+msgid "Confirm and we will take care of your yard."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1457
+msgid "Our experienced crews offer everything from routine lawn care to custom garden design, with eco-friendly treatment options available."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1459
+msgid "Do you offer seasonal maintenance plans?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1460
+msgid "Do I need to be home during service?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1460
+msgid "No, most yard services do not require you to be home."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1461
+msgid "Do you offer eco-friendly treatments?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1461
+msgid "Yes, ask about our eco-friendly fertilization and weed control options."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1462
+msgid "Can you design a new garden bed for me?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1462
+msgid "Yes, our garden bed design and planting service covers the whole process."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1478
+msgid "Lawn looks amazing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1478
+msgid "Jonas transformed our overgrown yard in one visit."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1479
+msgid "Great garden design"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1479
+msgid "Peter designed a beautiful garden bed we get compliments on."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1480
+msgid "Reliable biweekly service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1480
+msgid "Consistent, on-time mowing every two weeks."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1481
+msgid "Free estimate was accurate and the crew was professional."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1487
+#: Admin/data/MPWPB_Business_Templates_Data.php:1492
+msgid "Moving Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1491
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "Swift Move Relocation Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1493
+msgid "Stress-free moving, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1496
+msgid "Local Moving"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1497
+msgid "Packing & Specialty Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1501
+msgid "Local Move (Studio/1 Bed)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1501
+msgid "Full-service local move for a studio or one-bedroom home."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1502
+msgid "Local Move (2-3 Bed)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1502
+msgid "Full-service local move for a two- or three-bedroom home."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1503
+msgid "Full Packing Service"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1503
+msgid "Professional packing of your entire home before the move."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1504
+msgid "Furniture Disassembly & Reassembly"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1504
+msgid "Disassembly and reassembly of beds, tables, and large furniture."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1505
+msgid "Piano / Specialty Item Moving"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1505
+msgid "Careful handling and moving of pianos or other specialty items."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1509
+msgid "Extra Mover (per hour)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1509
+msgid "Add an additional mover to speed up your move."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1510
+msgid "Packing Supplies Kit"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1510
+msgid "Boxes, tape, and padding to prep for your move."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1511
+msgid "Storage (per week)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1511
+msgid "Secure short-term storage for your belongings."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1514
+msgid "Fully Insured Moving Crews"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1515
+msgid "Careful Handling Guaranteed"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1516
+msgid "Free On-Site or Virtual Estimates"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1517
+msgid "Flexible Scheduling Including Weekends"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "makes moving day smooth, fast, and stress-free."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "Choose a moving or packing service."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "Pick your move date and time."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1519
+msgid "Confirm and we will show up ready to move."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1520
+msgid "Our fully insured moving crews handle your belongings with care, from a single item to a full-home move, with flexible scheduling including weekends."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1522
+msgid "Are you insured?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1522
+msgid "Yes, all moves are covered by our moving insurance policy."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1523
+msgid "Do you provide packing materials?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1523
+msgid "Yes, packing supply kits are available as an add-on, or bring your own."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1524
+msgid "Can you move specialty items like pianos?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1524
+msgid "Yes, our crews are experienced in safely moving pianos and other specialty items."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1525
+msgid "Do you offer storage?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1525
+msgid "Yes, short-term storage is available as a weekly add-on."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1541
+msgid "Smooth move"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1541
+msgid "Adam's crew was fast, careful, and friendly the whole day."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1542
+msgid "Handled our piano perfectly"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1542
+msgid "Felix's team moved our piano without a scratch."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1543
+msgid "Fair pricing for a full day of moving help."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1544
+msgid "Booked a Sunday move with no hassle at all."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1550
+#: Admin/data/MPWPB_Business_Templates_Data.php:1555
+msgid "Pet Grooming & Pet Sitting"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1554
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+msgid "Happy Tails Pet Grooming"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1556
+msgid "Gentle grooming for happy pets, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1559
+msgid "Grooming Packages"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1560
+msgid "Add-On Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1564
+msgid "Bath & Brush (Small Dog)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1564
+msgid "Bath, blow-dry, and brush-out for small breeds."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1565
+msgid "Bath & Brush (Large Dog)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1565
+msgid "Bath, blow-dry, and brush-out for large breeds."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1566
+msgid "Full Groom (Small Dog)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1566
+msgid "Bath, haircut, nail trim, and ear cleaning for small breeds."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1567
+msgid "Full Groom (Large Dog)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1567
+msgid "Bath, haircut, nail trim, and ear cleaning for large breeds."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1568
+msgid "Cat Grooming Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1568
+msgid "Gentle bath, brush-out, and nail trim for cats."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1572
+msgid "Nail Trim"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1572
+msgid "Quick, gentle nail trim for dogs or cats."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1573
+msgid "Teeth Brushing"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1573
+msgid "Pet-safe teeth brushing to freshen breath."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1574
+msgid "De-Shedding Treatment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1574
+msgid "Specialized treatment to reduce shedding."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1577
+msgid "Certified Pet Groomers"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1578
+msgid "Calm, Low-Stress Environment"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1579
+msgid "All Breeds Welcome"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1580
+msgid "Flea & Tick Treatment Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+msgid "gives your pet a gentle, stress-free grooming experience."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+msgid "Choose a grooming package for your pet."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1582
+msgid "Confirm and drop off your pet for a pampering session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1583
+msgid "Our certified groomers work in a calm, low-stress environment and are experienced with all breeds and temperaments."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1585
+msgid "Is my pet safe during grooming?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1585
+msgid "Yes, all groomers are trained in safe handling and our facility is designed to keep pets calm."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1586
+msgid "Do you groom cats?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1586
+msgid "Yes, we offer gentle grooming sessions designed specifically for cats."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1587
+msgid "How long does a full groom take?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1587
+msgid "Full grooms typically take 1.5 to 2 hours depending on your pet's size and coat."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1588
+msgid "Is there a discount for a monthly grooming plan?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1588
+msgid "Yes -- ask about our monthly grooming plan with a recurring-booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1604
+msgid "My dog loves Bella"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1604
+msgid "He usually hates grooming but is always calm with Bella."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1605
+msgid "Great full groom"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1605
+msgid "Simon did an excellent job on our golden retriever."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1606
+msgid "Good with cats too"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1606
+msgid "Surprised how calm my usually skittish cat was."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1607
+msgid "Booked in two minutes, in and out fast at pickup."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1613
+#: Admin/data/MPWPB_Business_Templates_Data.php:1618
+msgid "Tutoring & Private Lessons"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1617
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "BrightPath Tutoring & Coaching"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1619
+msgid "Personalized learning support, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1622
+msgid "Academic Tutoring"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1623
+msgid "Test Prep & Coaching"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1627
+msgid "1-on-1 Tutoring Session (Elementary)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1627
+msgid "Personalized tutoring for elementary school subjects."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1628
+msgid "1-on-1 Tutoring Session (High School)"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1628
+msgid "Personalized tutoring for high school subjects."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1629
+msgid "Homework Help Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1629
+msgid "Guided homework help across multiple subjects."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1630
+msgid "SAT/ACT Test Prep Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1630
+msgid "Focused strategy and practice for SAT or ACT test prep."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1631
+msgid "Academic Coaching Session"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1631
+msgid "Study skills, organization, and time management coaching."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1635
+msgid "Extra 30 Minutes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1635
+msgid "Extend any tutoring session by 30 minutes."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1636
+msgid "Practice Test Grading & Review"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1636
+msgid "Detailed grading and review of a full practice test."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1637
+msgid "Study Plan Package"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1637
+msgid "Custom weekly study plan built around your goals."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1640
+msgid "Qualified, Vetted Tutors"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1641
+msgid "Personalized Learning Plans"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1642
+msgid "In-Person or Online Sessions"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1643
+msgid "Progress Reports for Parents"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "helps students build confidence and improve their grades."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "Choose a tutoring or test prep session."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1645
+msgid "Confirm and get ready to learn."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1646
+msgid "All tutors are vetted and experienced, offering personalized learning plans and progress updates so parents can track improvement."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1648
+msgid "Are sessions in-person or online?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1648
+msgid "Both options are available -- choose whichever works best for your family."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1649
+msgid "Do tutors provide progress updates?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1649
+msgid "Yes, parents receive a progress report after every few sessions."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1650
+msgid "Can I book a recurring weekly session?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1650
+msgid "Yes -- ask about our weekly recurring tutoring plan with a booking discount."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1651
+msgid "What subjects do you cover?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1651
+msgid "We cover core academic subjects plus SAT/ACT test prep -- contact us for a specific subject request."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1667
+msgid "Grades went up fast"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1667
+msgid "My son's math grade improved within a month of sessions with Nora."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1668
+msgid "Great SAT prep"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1668
+msgid "Ezra's strategies raised my score significantly."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1669
+msgid "Helpful progress reports"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1669
+msgid "Love getting updates on what we are working on each week."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1670
+msgid "Patient and encouraging"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1670
+msgid "Both tutors are patient and my daughter actually enjoys the sessions."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1676
+#: Admin/data/MPWPB_Business_Templates_Data.php:1681
+msgid "Event Planning & Equipment Rental"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1680
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "Occasion Event Decor Co."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1682
+msgid "Beautiful event styling, booked online"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1685
+msgid "Event Styling Packages"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1686
+msgid "Add-On Decor Services"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1690
+msgid "Birthday Party Decoration Package"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1690
+msgid "Full birthday party styling including balloons and table decor."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1691
+msgid "Wedding Decoration Package"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1691
+msgid "Full-venue wedding styling including ceremony and reception decor."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1692
+msgid "Corporate Event Styling"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1692
+msgid "Professional styling for corporate events and conferences."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1693
+msgid "Balloon Garland Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1693
+msgid "Custom balloon garland designed to match your event colors."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1694
+msgid "Backdrop & Centerpiece Setup"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1694
+msgid "Custom backdrop and table centerpiece setup for photos."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1698
+msgid "Additional Balloon Arch"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1698
+msgid "An extra balloon arch for a second area of your venue."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1699
+msgid "Fresh Flower Upgrade"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1699
+msgid "Upgrade centerpieces and decor to fresh flowers."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1700
+msgid "Fairy Light Installation"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1700
+msgid "Warm fairy lights added throughout your venue."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1703
+msgid "Custom Themes & Color Palettes"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1704
+msgid "Full Setup & Teardown Included"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1705
+msgid "Experienced Event Stylists"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1706
+msgid "Rental Decor Inventory Available"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "brings your event vision to life, from intimate parties to full weddings."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "Choose an event styling package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "Add any decor extras."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1708
+msgid "Confirm and we will handle setup and teardown."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1709
+msgid "Our stylists design custom themes and color palettes for every event, with full setup and teardown included in every package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1711
+msgid "Do you handle setup and teardown?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1711
+msgid "Yes, full setup and teardown is included in every styling package."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1712
+msgid "Can I request a custom color theme?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1712
+msgid "Yes, all packages can be customized to your event's color palette and theme."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1713
+msgid "How far in advance should I book?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1713
+msgid "We recommend booking at least 2-4 weeks ahead, earlier for weddings."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1714
+msgid "Do you offer decor rentals only, without styling?"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1714
+msgid "Contact us directly to discuss rental-only options for your event."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1730
+msgid "Dream wedding decor"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1730
+msgid "Camille brought our vision to life perfectly, down to every detail."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1731
+msgid "Great corporate event"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1731
+msgid "Xavier styled our conference beautifully on a tight timeline."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1732
+msgid "Lovely balloon garland"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1732
+msgid "Exactly the colors we wanted for our daughter's birthday."
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1733
+msgid "Stress-free planning"
+msgstr ""
+
+#: Admin/data/MPWPB_Business_Templates_Data.php:1733
+msgid "They handled everything so we could just enjoy the party."
+msgstr ""
+
+#: Admin/MPWPB_Admin.php:113
+msgid "No service to duplicate has been supplied."
+msgstr ""
+
+#: Admin/MPWPB_Admin.php:116
+#: Admin/MPWPB_Native_Checkout_Settings.php:37
+#: Admin/MPWPB_Native_Checkout_Settings.php:59
+#: Admin/MPWPB_Native_Checkout_Settings.php:86
+#: Admin/MPWPB_Native_Checkout_Settings.php:1125
+#: Admin/MPWPB_Reviews_Admin.php:935
+#: Frontend/MPWPB_Coupon_Frontend.php:50
+#: Frontend/MPWPB_Coupon_Frontend.php:66
+#: Frontend/MPWPB_Native_Checkout.php:123
+#: Frontend/MPWPB_Native_Checkout.php:785
+#: Frontend/MPWPB_Native_Checkout.php:787
+#: Frontend/MPWPB_Recurring_Account_Manager.php:263
+#: Frontend/MPWPB_Staff_Booking.php:289
+#: mp_global/class/MPWPB_Booking_Notes.php:190
+#: mp_global/class/MPWPB_Partial_Payment.php:211
+msgid "Security check failed."
+msgstr ""
+
+#: Admin/MPWPB_Admin.php:121
+#: Admin/MPWPB_Service_List.php:44
+msgid "You are not allowed to duplicate this service."
+msgstr ""
+
+#: Admin/MPWPB_Admin.php:182
+msgid "Duplicate Post"
+msgstr ""
+
+#: Admin/MPWPB_Admin.php:182
+msgid "Duplicate"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Ajax.php:24
+#: Admin/MPWPB_Analytics_Ajax.php:55
+#: Admin/MPWPB_Staff_DashBoard.php:69
+#: Admin/MPWPB_Staff_DashBoard.php:739
+#: Admin/MPWPB_Staff_DashBoard.php:772
+#: Admin/MPWPB_Staff_DashBoard.php:816
+#: Admin/settings/Recurring_Booking.php:109
+#: Admin/settings/Recurring_Booking.php:211
+#: Admin/settings/Waiting_List.php:155
+#: Admin/settings/Waiting_List.php:187
+#: Frontend/MPWPB_Recurring_Booking.php:61
+#: Frontend/MPWPB_User_Dashboard.php:816
+#: Frontend/MPWPB_User_Dashboard.php:925
+#: Frontend/MPWPB_User_Dashboard.php:958
+#: Frontend/MPWPB_User_Dashboard.php:1010
+#: Frontend/MPWPB_User_Dashboard.php:1052
+#: Frontend/MPWPB_User_Dashboard.php:1073
+#: Frontend/MPWPB_User_Dashboard.php:1098
+msgid "Security check failed"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Ajax.php:29
+#: Admin/MPWPB_Analytics_Ajax.php:60
+msgid "Insufficient permissions"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Ajax.php:75
+msgid "Data exported successfully"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Ajax.php:215
+#: Admin/MPWPB_Analytics_Ajax.php:327
+#: Admin/MPWPB_Analytics_Dashboard.php:180
+#: Admin/MPWPB_Analytics_Dashboard.php:190
+msgid "Bookings"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:26
+msgid "Analytics Dashboard"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:27
+#: Admin/MPWPB_Help_Guide_Content.php:57
+msgid "Analytics"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:52
+msgid "Service Booking Analytics Dashboard"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:61
+msgid "Date Range:"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:63
+msgid "Last 7 Days"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:64
+msgid "Last 30 Days"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:65
+msgid "Last 90 Days"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:66
+msgid "Last Year"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:67
+msgid "Custom Range"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:72
+msgid "Start Date:"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:75
+msgid "End Date:"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:80
+msgid "Service:"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:94
+#: Admin/MPWPB_Reviews_Admin.php:202
+#: Admin/MPWPB_Reviews_Admin.php:394
+#: Admin/MPWPB_Staff_DashBoard.php:1198
+msgid "Filter"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:95
+#: Admin/MPWPB_Reviews_Admin.php:86
+msgid "Export CSV"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:106
+#: Frontend/MPWPB_User_Dashboard.php:702
+msgid "Total Bookings"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:108
+msgid "All time bookings"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:114
+msgid "Revenue"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:116
+msgid "Total revenue generated"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:122
+msgid "Avg. Booking Value"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:124
+msgid "Average per booking"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:130
+msgid "Conversion Rate"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:132
+msgid "Visitors to bookings"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:141
+msgid "Bookings Over Time"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:150
+msgid "Top Services"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:161
+msgid "Recent Bookings"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:907
+msgid "Showing latest 5 orders. Upgrade to Pro to see all orders."
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:909
+msgid "Showing all orders (Pro version)."
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:915
+#: Admin/MPWPB_Staff_DashBoard.php:373
+#: Admin/MPWPB_Staff_DashBoard.php:1331
+#: Frontend/MPWPB_User_Dashboard.php:237
+msgid "Booking ID"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:916
+#: Admin/MPWPB_Native_Order_List.php:106
+#: Admin/MPWPB_Reviews_Admin.php:220
+#: Admin/MPWPB_Reviews_Admin.php:412
+#: Admin/MPWPB_Settings_Global.php:191
+#: Admin/MPWPB_Staff_DashBoard.php:374
+#: Admin/MPWPB_Staff_DashBoard.php:1179
+#: Admin/MPWPB_Staff_DashBoard.php:1332
+#: Frontend/MPWPB_Static_Template.php:33
+#: Frontend/MPWPB_Stripe_Gateway.php:84
+#: Frontend/MPWPB_User_Dashboard.php:238
+#: Frontend/MPWPB_User_Dashboard.php:506
+#: inc/MPWPB_Function.php:114
+#: mp_global/class/MPWPB_Cancellation.php:190
+#: mp_global/class/MPWPB_Cancellation.php:212
+#: templates/layout/service_list.php:314
+msgid "Service"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:917
+#: Admin/MPWPB_Reviews_Admin.php:224
+#: Admin/MPWPB_Staff_DashBoard.php:375
+#: Admin/MPWPB_Staff_DashBoard.php:1334
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:418
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:440
+#: Frontend/MPWPB_Recurring_Account_Manager.php:92
+#: Frontend/MPWPB_User_Dashboard.php:239
+#: Frontend/MPWPB_Woocommerce.php:1075
+msgid "Date"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:918
+#: Admin/MPWPB_Cancellation_Requests.php:147
+#: Admin/MPWPB_Gdpr_Requests.php:292
+#: Admin/MPWPB_Native_Order_List.php:134
+#: Admin/MPWPB_Reviews_Admin.php:221
+#: Admin/MPWPB_Reviews_Admin.php:411
+#: Admin/MPWPB_Reviews_Admin.php:869
+#: Admin/MPWPB_Staff_DashBoard.php:1333
+#: Frontend/MPWPB_User_Dashboard.php:574
+#: mp_global/class/MPWPB_Cancellation.php:169
+#: mp_global/class/MPWPB_Cancellation.php:188
+msgid "Customer"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:919
+#: Admin/MPWPB_Coupon_List.php:110
+#: Admin/MPWPB_Gdpr_Requests.php:296
+#: Admin/MPWPB_Help_Guide_Content.php:53
+#: Admin/MPWPB_Native_Order_List.php:105
+#: Admin/MPWPB_Native_Order_List.php:137
+#: Admin/MPWPB_Reviews_Admin.php:225
+#: Admin/MPWPB_Settings_Global.php:588
+#: Admin/MPWPB_Staff_DashBoard.php:377
+#: Admin/MPWPB_Staff_DashBoard.php:1047
+#: Admin/MPWPB_Staff_DashBoard.php:1336
+#: Admin/MPWPB_Staff_DashBoard.php:1520
+#: Admin/MPWPB_Staff_Members.php:384
+#: Admin/MPWPB_Status.php:16
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:320
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:419
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:441
+#: Frontend/MPWPB_User_Dashboard.php:241
+#: templates/layout/coupon_list.php:169
+#: templates/layout/service_list.php:316
+msgid "Status"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:920
+msgid "Amount"
+msgstr ""
+
+#: Admin/MPWPB_Analytics_Dashboard.php:955
+msgid "No bookings found."
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:47
+#: templates/layout/service_list.php:299
+msgid "One-Click Business Templates"
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:48
+msgid "Choose a business type to create a fully configured, ready-to-book service business in seconds. Everything imported stays fully editable afterward."
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:49
+msgid "Use This Template"
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:50
+msgid "Services Included"
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:51
+msgid "Creating your business…"
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:52
+msgid "Something went wrong. Please try again."
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:78
+msgid "Invalid nonce!"
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:81
+#: Admin/MPWPB_Dummy_Import.php:314
+msgid "Permission denied."
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:86
+msgid "Unknown template."
+msgstr ""
+
+#: Admin/MPWPB_Business_Templates_Import.php:403
+#: Admin/MPWPB_Reviews_Admin.php:1447
+msgid "Out of 5"
+msgstr ""
+
+#. translators: %d: number of ratings
+#: Admin/MPWPB_Business_Templates_Import.php:406
+#: Admin/MPWPB_Reviews_Admin.php:1449
+#, php-format
+msgid "(%d ratings)"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:21
+#: Admin/MPWPB_Cancellation_Requests.php:27
+#: Admin/MPWPB_Cancellation_Requests.php:90
+msgid "Cancellation Requests"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:77
+#: Admin/MPWPB_Cancellation_Requests.php:170
+msgid "You do not have permission to review cancellation requests."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:91
+msgid "Review customer requests before a booking and its order are cancelled."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:93
+#, php-format
+msgid "%d pending request"
+msgid_plural "%d pending requests"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:97
+msgid "Cancellation approved. The booking/order was cancelled and the customer was emailed."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:99
+msgid "Cancellation approved and the booking/order was cancelled, but WordPress could not hand off the customer email. Configure a working SMTP transport and contact the customer manually."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:101
+msgid "Cancellation request rejected. The booking remains active and the customer was emailed."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:103
+msgid "The request was rejected and the booking remains active, but WordPress could not hand off the customer email. Configure a working SMTP transport and contact the customer manually."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:105
+msgid "The request could not be updated. It may already have been reviewed."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:109
+#: Admin/MPWPB_Native_Order_List.php:91
+#: Admin/MPWPB_Native_Order_List.php:287
+#: Admin/MPWPB_Native_Order_List.php:296
+#: Admin/MPWPB_Reviews_Admin.php:184
+#: Admin/MPWPB_Settings_Global.php:266
+msgid "Pending"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:109
+#: Admin/MPWPB_Reviews_Admin.php:183
+msgid "Approved"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:109
+msgid "Rejected"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:109
+#: Admin/MPWPB_Help_Guide.php:164
+#: Admin/MPWPB_Reviews_Admin.php:386
+#: templates/layout/coupon_list.php:148
+msgid "All"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:115
+msgid "No cancellation requests here"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:115
+msgid "New customer requests will appear on this screen."
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:143
+#, php-format
+msgid "Booking #%d"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:148
+#: Frontend/MPWPB_User_Dashboard.php:507
+msgid "Appointment"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:149
+#: Admin/MPWPB_Native_Order_List.php:133
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:417
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:433
+#: Frontend/MPWPB_User_Dashboard.php:505
+#: mp_global/class/MPWPB_Cancellation.php:186
+msgid "Order"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:149
+#, php-format
+msgid "Open order #%d"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:150
+#: Admin/MPWPB_Gdpr_Requests.php:293
+msgid "Requested"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:152
+msgid "Customer reason"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:158
+msgid "Message to customer (optional)"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:158
+msgid "Add context for your decision…"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:159
+msgid "Approve cancellation"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:159
+msgid "Reject request"
+msgstr ""
+
+#: Admin/MPWPB_Cancellation_Requests.php:162
+msgid "Administrator note"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:16
+#: Admin/MPWPB_Coupon_CPT.php:18
+#: Admin/MPWPB_Coupon_List.php:21
+#: Admin/MPWPB_Help_Guide_Content.php:52
+#: Admin/MPWPB_Help_Guide_Content.php:177
+#: templates/layout/coupon_list.php:110
+msgid "Coupons"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:17
+#: Admin/MPWPB_Coupon_CPT.php:19
+#: templates/layout/coupon_list.php:166
+msgid "Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:20
+msgid "All Coupons"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:21
+#: Admin/MPWPB_Coupon_CPT.php:22
+#: templates/layout/coupon_list.php:157
+msgid "Add New Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:23
+msgid "New Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:24
+#: Admin/MPWPB_Coupon_List.php:102
+#: templates/layout/coupon_list.php:89
+msgid "Edit Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:25
+#: Admin/MPWPB_Coupon_List.php:125
+msgid "Update Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:26
+msgid "View Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:27
+msgid "Search Coupons"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:28
+msgid "No coupons found"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_CPT.php:29
+msgid "No coupons found in Trash"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:62
+msgid "Loading coupon…"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:63
+#: Admin/MPWPB_Native_Checkout_Settings.php:1004
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:821
+msgid "Saving…"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:64
+msgid "The coupon could not be saved. Please try again."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:65
+msgid "Move this coupon to Trash?"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:71
+msgid "Security check failed. Refresh the page and try again."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:74
+msgid "You do not have permission to manage coupons."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:82
+#: Admin/MPWPB_Coupon_List.php:326
+#: Admin/MPWPB_Coupon_List.php:378
+msgid "Coupon not found or not editable."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:101
+msgid "Booking promotion"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:102
+#: Admin/MPWPB_Coupon_List.php:125
+msgid "Create Coupon"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:103
+msgid "Configure the offer, eligibility and usage rules in one place."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:106
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:298
+msgid "Close"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:109
+#: Admin/MPWPB_Coupon_Settings.php:84
+msgid "Coupon name"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:109
+msgid "Summer campaign"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:110
+#: Admin/MPWPB_Coupon_Settings.php:76
+#: Admin/MPWPB_Settings_Global.php:599
+#: Frontend/MPWPB_User_Dashboard.php:690
+#: templates/layout/coupon_list.php:66
+#: templates/layout/coupon_list.php:126
+#: templates/layout/coupon_list.php:149
+msgid "Active"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:110
+msgid "Inactive / Draft"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:118
+msgid "Schedule & Staff"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:119
+#: templates/layout/coupon_list.php:168
+msgid "Usage"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:125
+#: Admin/MPWPB_Staff_DashBoard.php:396
+#: Admin/MPWPB_Staff_DashBoard.php:514
+#: Admin/MPWPB_Staff_Members.php:272
+#: Admin/MPWPB_Staff_Members.php:273
+#: Frontend/MPWPB_Static_Template.php:507
+msgid "Cancel"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:158
+msgid "Enter a coupon name."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:162
+msgid "Coupon name must be 160 characters or fewer."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:167
+msgid "Enter a coupon code."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:170
+msgid "Use up to 64 letters, numbers, hyphens or underscores for the coupon code."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:174
+#: Admin/MPWPB_Coupon_Settings.php:165
+msgid "That coupon code is already in use."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:180
+msgid "Enter a valid start date."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:183
+msgid "Enter a valid expiry date."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:186
+msgid "Expiry date must be on or after the start date."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:191
+msgid "Select a valid discount type."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:196
+msgid "Enter a discount value greater than zero."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:199
+msgid "Percentage discount cannot exceed 100%."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:205
+msgid "Select a valid service scope."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:211
+#: Frontend/MPWPB_Recurring_Account_Manager.php:291
+msgid "Select at least one service."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:214
+msgid "One or more selected services are invalid."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:221
+msgid "Minimum booking total cannot be negative."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:224
+msgid "Maximum booking total cannot be negative."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:227
+msgid "Maximum booking total must be at least the minimum total."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:233
+msgid "Minimum quantity must be a whole number of zero or more."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:236
+msgid "Maximum quantity must be a whole number of zero or more."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:239
+msgid "Maximum quantity must be at least the minimum quantity."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:245
+msgid "Select a valid booking-history restriction."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:248
+msgid "Select a valid account restriction."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:255
+msgid "Select a valid day restriction."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:258
+msgid "Select a valid booking-date mode."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:261
+msgid "Select a valid time restriction."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:267
+msgid "Enter at least one booking date."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:271
+msgid "Booking dates must use the YYYY-MM-DD format."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:277
+msgid "Select a valid time-of-day option."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:283
+msgid "Select a valid start time."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:286
+msgid "Select an end time different from the start time."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:292
+msgid "Select a valid staff restriction."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:297
+msgid "Select at least one staff member."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:302
+msgid "One or more selected staff members are invalid."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:310
+msgid "Total usage limit must be a whole number greater than zero."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:313
+msgid "Per-customer limit must be a whole number greater than zero."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:316
+msgid "Per-customer limit cannot exceed the total usage limit."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:351
+msgid "The coupon could not be saved."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:362
+msgid "Coupon saved instantly."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:391
+msgid "Coupon not found or not removable."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:394
+msgid "The coupon could not be moved to Trash."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:402
+msgid "Invalid coupon."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:405
+msgid "(Copy)"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_List.php:411
+msgid "Failed to duplicate coupon."
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:18
+msgid "Coupon Settings"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:74
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:246
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:773
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:829
+msgid "Update"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:74
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:246
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:773
+msgid "Publish"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:75
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:247
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:774
+msgid "Switch to Draft"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:75
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:247
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:774
+msgid "Save Draft"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:76
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:248
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:772
+#: templates/layout/service_list.php:294
+msgid "Draft"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:82
+msgid "Back to Coupons"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:91
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:263
+msgid "More save options"
+msgstr ""
+
+#: Admin/MPWPB_Coupon_Settings.php:97
+msgid "Move to Trash"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:51
+#: Admin/MPWPB_CPT.php:52
+msgid " List"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:53
+msgid " Item:"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:54
+#: Admin/MPWPB_Taxonomy.php:22
+msgid "All "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:55
+#: Admin/MPWPB_CPT.php:56
+#: Admin/settings/Service.php:204
+#: Admin/settings/Service.php:303
+msgid "Add Service"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:57
+#: Admin/MPWPB_Taxonomy.php:25
+msgid "New "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:58
+#: Admin/MPWPB_Taxonomy.php:27
+msgid "Edit "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:59
+#: Admin/MPWPB_Taxonomy.php:28
+msgid "Update "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:60
+#: Admin/MPWPB_CPT.php:61
+#: Admin/MPWPB_Taxonomy.php:29
+msgid "View "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:62
+#: Admin/MPWPB_Taxonomy.php:34
+msgid "Search "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:63
+msgid " Not found"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:64
+msgid " Not found in Trash"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:65
+msgid " Feature Image"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:66
+msgid "Set "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:66
+#: Admin/MPWPB_CPT.php:67
+#: Admin/MPWPB_CPT.php:68
+msgid " featured image"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:67
+msgid "Remove "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:68
+msgid "Use as"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:69
+msgid "Insert into"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:70
+msgid "Uploaded to this "
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:71
+#: Admin/MPWPB_CPT.php:73
+#: Admin/MPWPB_Taxonomy.php:37
+msgid " list"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:72
+#: Admin/MPWPB_Taxonomy.php:38
+msgid " list navigation"
+msgstr ""
+
+#: Admin/MPWPB_CPT.php:73
+msgid "Filter "
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:92
+msgid "Skip"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:112
+#: Admin/MPWPB_Dummy_Import.php:140
+msgid "Importing Services"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:113
+msgid "Preparing…"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:141
+msgid "Preparing demo data…"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:142
+msgid "Adding"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:143
+msgid "Import complete!"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:144
+msgid "All set — reloading…"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:145
+msgid "Connection hiccup — retrying…"
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:146
+msgid "Import failed. Please try again."
+msgstr ""
+
+#: Admin/MPWPB_Dummy_Import.php:147
+msgid "Demo data is already present."
+msgstr ""
+
+#: Admin/MPWPB_Extended_Settings.php:35
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:138
+#: Frontend/MPWPB_Recurring_Booking.php:230
+#: Frontend/MPWPB_Recurring_Booking.php:290
+msgid "Recurring Booking"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:42
+msgid "GDPR Data Requests"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:55
+msgctxt "GDPR request status"
+msgid "Pending"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:61
+msgctxt "GDPR request status"
+msgid "Approved"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:67
+msgctxt "GDPR request status"
+msgid "Rejected"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:85
+msgid "You already have a pending data request awaiting admin review."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:88
+msgid "Please choose a valid request type."
+msgstr ""
+
+#. translators: %s: customer display name or ID
+#: Admin/MPWPB_Gdpr_Requests.php:96
+#, php-format
+msgid "GDPR request from %s"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:102
+msgid "Could not submit your request. Please try again."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:137
+#: Frontend/MPWPB_User_Dashboard.php:1078
+msgid "Invalid request."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:140
+#: Admin/MPWPB_Native_Checkout_Settings.php:34
+#: Admin/MPWPB_Native_Checkout_Settings.php:55
+#: Admin/MPWPB_Native_Checkout_Settings.php:82
+#: Admin/MPWPB_Native_Checkout_Settings.php:1122
+#: Admin/MPWPB_Reviews_Admin.php:976
+#: Admin/MPWPB_Reviews_Admin.php:1015
+#: mp_global/class/MPWPB_Booking_Notes.php:234
+msgid "You do not have permission to do this."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:145
+msgid "Request not found."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:148
+msgid "This request has already been resolved."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:156
+msgid "Unknown action."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:280
+msgid "Profile"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:281
+#: Admin/MPWPB_Staff_DashBoard.php:561
+#: Frontend/MPWPB_Native_Checkout.php:738
+msgid "Phone"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:282
+#: Admin/MPWPB_Staff_DashBoard.php:568
+#: Admin/MPWPB_Staff_DashBoard.php:1550
+#: Frontend/MPWPB_Native_Checkout.php:444
+#: Frontend/MPWPB_Native_Checkout.php:637
+#: Frontend/MPWPB_Native_Checkout.php:743
+msgid "Address"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:283
+msgid "Notes"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:287
+msgid "Customer Data Requests"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:288
+msgid "Customer-submitted data requests wait here for your approval before anything is changed."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:294
+msgid "Strategy"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:295
+msgid "Options"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:297
+#: Admin/MPWPB_Settings_Global.php:589
+#: Admin/MPWPB_Staffs.php:118
+#: Admin/MPWPB_Staff_Members.php:127
+msgid "Action"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:302
+msgid "No data requests yet."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:322
+msgid "Unknown user"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:327
+#: Frontend/MPWPB_User_Dashboard.php:761
+msgid "Completely remove everything"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:327
+#: Frontend/MPWPB_User_Dashboard.php:748
+msgid "Keep booking for accounting"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:328
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:443
+msgid "None"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:332
+#: Admin/MPWPB_Reviews_Admin.php:287
+#: Admin/MPWPB_Reviews_Admin.php:289
+msgid "Approve"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:333
+#: Admin/MPWPB_Gdpr_Settings.php:69
+#: Frontend/MPWPB_Gdpr_Cookie_Banner.php:30
+msgid "Reject"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:353
+msgid "Approve this request? The selected data will be changed immediately and this cannot be undone."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Requests.php:354
+msgid "Reject this request? No data will be changed."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:39
+msgid "GDPR"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:47
+msgid "Enable GDPR Feature"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:48
+msgid "Turns on the cookie consent banner and adds privacy consent checkboxes to the booking form. Off by default."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:54
+msgid "Cookie Banner Message"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:55
+msgid "Shown in the cookie consent banner on the frontend."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:57
+#: Frontend/MPWPB_Gdpr_Cookie_Banner.php:28
+msgid "We use cookies to remember your booking details and improve your experience. Do you accept?"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:61
+msgid "Accept Button Text"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:63
+#: Frontend/MPWPB_Gdpr_Cookie_Banner.php:29
+msgid "Accept"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:67
+msgid "Reject Button Text"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:73
+msgid "Privacy Policy Page"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:74
+msgid "Linked from the Privacy Policy checkbox on the booking form."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:80
+msgid "Privacy Policy Checkbox Text"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:82
+#: Frontend/MPWPB_Gdpr_Wc_Consent.php:23
+#: Frontend/MPWPB_Native_Checkout.php:468
+msgid "I agree to the Privacy Policy."
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:86
+msgid "Data Processing Checkbox Text"
+msgstr ""
+
+#: Admin/MPWPB_Gdpr_Settings.php:88
+#: Frontend/MPWPB_Gdpr_Wc_Consent.php:24
+#: Frontend/MPWPB_Native_Checkout.php:469
+msgid "I consent to my personal data being processed for this booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:19
+#: Admin/MPWPB_Help_Guide.php:128
+msgid "WPBookingly Help Center"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:20
+msgid "Help & Guide"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:47
+msgid "Topic link copied."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:48
+msgid "Copy the address from your browser."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:49
+msgid "This guide topic requires Service Booking Manager Pro to be active."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:117
+msgid "You do not have permission to view this guide."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:127
+msgid "Booking management, explained clearly"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:129
+msgid "Find any feature, understand every setting, and follow practical steps to configure your booking system with confidence."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:133
+msgid "Free + Pro guide"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:133
+msgid "Free guide"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:136
+msgid "Search the guide"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:138
+msgid "Try “buffer time”, “coupon”, “Stripe”…"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:145
+msgid "Quick start"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:146
+msgid "Create a service"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:147
+msgid "Set availability"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:148
+msgid "Choose payments"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:149
+msgid "Assign staff"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:150
+msgid "Test a booking"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:155
+msgid "Jump to a section"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:157
+msgid "Choose a section…"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:163
+msgid "Filter guide"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:165
+#: Admin/MPWPB_Help_Guide.php:205
+#: Admin/MPWPB_Help_Guide.php:225
+#: Admin/MPWPB_Settings_Global.php:595
+msgid "Free"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:166
+#: Admin/MPWPB_Help_Guide.php:205
+#: Admin/MPWPB_Help_Guide.php:225
+msgid "Pro"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:168
+msgid "Expand all"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:173
+msgid "Guide sections"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:174
+msgid "Guide contents"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:179
+#: Admin/MPWPB_Native_Checkout_Settings.php:639
+#: Admin/MPWPB_Native_Order_List.php:305
+#: Admin/MPWPB_Native_Order_List.php:312
+#: Admin/MPWPB_Pro_Locked_Menus.php:32
+#: Admin/MPWPB_Pro_Locked_Menus.php:113
+#: Admin/MPWPB_Pro_Upsell_Notice.php:100
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:583
+#: Admin/settings/Happy_Hours.php:55
+msgid "PRO"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:179
+msgid "FREE"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:188
+msgid "No guide topics found"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:189
+msgid "Try a simpler term such as service, schedule, payment, staff, coupon, or email."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:190
+msgid "Clear search"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:229
+msgid "Where to find it"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:234
+msgid "Settings explained"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:239
+msgid "Open this area"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide.php:240
+msgid "Copy topic link"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:26
+msgid "Start Here"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:26
+msgid "A practical path from installation to a successful test booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:27
+msgid "Five-step launch checklist"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:27
+msgid "Complete the essential setup in the right order."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:27
+msgid "WPBookingly menu"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:29
+msgid "Create a service and give it a clear public title."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:30
+msgid "Add services, prices, duration, capacity, and optional extras."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:31
+msgid "Set bookable dates, working hours, breaks, and unavailable dates."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:32
+msgid "Choose WooCommerce or the available checkout mode and confirm its settings."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:33
+msgid "Publish the service, open it as a customer, and complete a real test booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:37
+msgid "Run your first test booking"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:37
+msgid "Test the full customer journey before sharing a service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:37
+msgid "WPBookingly → Service List → View a published service"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:39
+msgid "Use a future date that has available working hours."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:40
+msgid "Select a service, staff member if enabled, and any extras."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:41
+msgid "Complete checkout with a test-safe payment method."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:42
+msgid "Confirm the booking appears in the appropriate order or booking view and that emails arrive."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:44
+msgid "Use a separate customer email address so you can check exactly what a real customer receives."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:49
+msgid "Admin Map"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:49
+msgid "Know which screen to open for each everyday task."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:50
+msgid "Where everything lives"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:50
+msgid "A quick map of the WPBookingly administration area."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:50
+msgid "WordPress Admin → WPBookingly"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:51
+#: Admin/MPWPB_Service_List.php:14
+msgid "Service List"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:51
+msgid "Create, edit, duplicate, publish, and preview bookable services."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:52
+msgid "Create promotional codes and control when, where, and how often each code works."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:53
+msgid "Check server, WordPress, WooCommerce, and supporting-component health."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:54
+#: Admin/MPWPB_Reviews_Admin.php:55
+#: Admin/MPWPB_Reviews_Admin.php:56
+#: Frontend/MPWPB_Static_Template.php:178
+msgid "Reviews"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:54
+msgid "Review customer feedback and moderate its visibility."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:55
+#: Admin/MPWPB_Staffs.php:32
+#: Admin/MPWPB_Staff_Members.php:31
+#: Frontend/MPWPB_Static_Template.php:563
+msgid "Staff Members"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:55
+msgid "Create staff profiles, assign services, and manage personal working schedules."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:56
+#: Admin/MPWPB_Settings_Global.php:26
+msgid "Settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:56
+msgid "Control global labels, URLs, checkout, privacy, display, timing, and appearance."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:57
+msgid "Measure bookings and revenue, filter results, and export CSV data."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:61
+msgid "Creating a Service"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:61
+msgid "Build the information, choices, pricing, and presentation customers see."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:62
+msgid "General information and display"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:62
+msgid "Name the service and control its public presentation."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:62
+msgid "WPBookingly → Service List → Add New or Edit → General"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:63
+msgid "Service title"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:63
+msgid "The main public name shown in WordPress and the booking page."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:63
+msgid "Use a specific customer-friendly name such as “60-minute Consultation”."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:64
+msgid "Shortcode title"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:64
+msgid "Optional heading displayed above the embedded booking interface."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:65
+msgid "Shortcode subtitle"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:65
+msgid "Supporting sentence shown with the booking interface."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:66
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:484
+msgid "Template"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:66
+msgid "Chooses the available frontend layout for this service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:67
+msgid "Featured image / thumbnail"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:67
+msgid "The primary visual used in service cards and the service page."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:68
+msgid "Service overview"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:68
+msgid "Controls and supplies the longer introduction customers read before booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:70
+msgid "Categories and service choices"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:70
+msgid "Organize related choices and define each billable service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:70
+msgid "Edit Service → Categories & Services"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:71
+msgid "Enable multiple categories"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:71
+msgid "Allows the booking form to present more than one category group."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:72
+msgid "Enable multiple service selection"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:72
+msgid "Lets a customer choose more than one service in the same booking where supported."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:73
+#: Admin/MPWPB_Settings_Global.php:147
+#: Admin/MPWPB_Settings_Global.php:177
+#: Admin/MPWPB_Staff_DashBoard.php:1046
+#: inc/MPWPB_Function.php:91
+#: inc/MPWPB_Function.php:106
+msgid "Category"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:73
+msgid "A top-level group such as Cleaning, Beauty, or Consultation."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:74
+msgid "Subcategory"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:74
+msgid "An optional second level used to keep a large catalog easy to scan."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:75
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:239
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:639
+msgid "Service name"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:75
+msgid "The choice the customer selects inside a category."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:76
+#: Admin/settings/Extra_service.php:266
+#: Admin/settings/Service.php:189
+#: Admin/settings/Service.php:233
+#: Admin/settings/Service.php:332
+#: Frontend/MPWPB_Woocommerce.php:1058
+#: Frontend/MPWPB_Woocommerce.php:1099
+msgid "Price"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:76
+msgid "Base cost for one unit of this service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:77
+msgid "Unit"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:77
+msgid "Explains what the price covers, such as person, room, hour, or item."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:78
+#: Admin/settings/Service.php:190
+#: Admin/settings/Service.php:241
+#: Admin/settings/Service.php:340
+msgid "Duration"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:78
+msgid "Customer-facing duration text for this choice."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:79
+msgid "Short details that help the customer choose correctly."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:80
+#: Admin/MPWPB_Help_Guide_Content.php:87
+msgid "Image or icon"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:80
+msgid "Visual identifier shown with the choice."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:82
+msgid "Extra services"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:82
+msgid "Offer optional add-ons alongside the main booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:82
+msgid "Edit Service → Extra Services"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:83
+msgid "Extra service name"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:83
+msgid "The add-on label customers see, such as “Deep conditioning”."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:84
+msgid "Extra price"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:84
+msgid "Additional amount charged for each selected extra."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:85
+msgid "Available quantity"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:85
+msgid "Maximum quantity a customer may choose."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:86
+msgid "Clarifies what the extra includes."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:87
+msgid "Makes the optional add-on easier to identify."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:89
+msgid "Details, features, FAQ, ratings, and gallery"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:89
+msgid "Add the information customers need before making a decision."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:89
+msgid "Edit Service → Service Features / Details / FAQ / Gallery"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:90
+msgid "Feature or detail rows"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:90
+msgid "Structured highlights such as inclusions, facilities, or benefits."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:91
+msgid "Displayed rating"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:91
+msgid "Optional rating value presented in the service information."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:92
+msgid "Rating scale"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:92
+msgid "Explains the maximum score, for example “Out of 5”."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:93
+msgid "Rating text"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:93
+msgid "Supporting text such as the number of ratings."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:94
+msgid "FAQ question and answer"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:94
+msgid "Reusable customer guidance shown as common questions."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:95
+msgid "Gallery images"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:95
+msgid "Additional photos that explain the location, result, or experience."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:99
+msgid "Availability & Scheduling"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:99
+msgid "Control which dates and times customers can actually reserve."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:100
+msgid "Service dates, hours, slots, and capacity"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:100
+msgid "Build the service’s bookable calendar and prevent invalid slots."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:100
+msgid "Edit Service → Date & Time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:101
+msgid "Date type"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:101
+msgid "Choose a repeating schedule or a list of particular dates."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:102
+msgid "Repeated start date"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:102
+msgid "First day from which the repeating schedule can be booked."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:103
+msgid "Repeat for / repeated after"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:103
+msgid "Defines the repeating schedule window."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:104
+msgid "Active days"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:104
+msgid "Limits how far or how many days the repeating availability remains active."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:105
+msgid "Time-slot length"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:105
+msgid "Splits working hours into selectable appointment intervals."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:105
+msgid "Match this to the real time needed for one appointment."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:106
+msgid "Capacity per session"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:106
+msgid "Maximum bookings accepted for the same slot."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:107
+msgid "Particular dates"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:107
+msgid "Explicit dates used when availability is not weekly or repeating."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:108
+msgid "Off days / off dates"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:108
+msgid "Dates that must remain unavailable even if normal hours would allow booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:109
+msgid "Weekday start and end time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:109
+msgid "Opening and closing time for each active weekday."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:110
+msgid "Break start and end time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:110
+msgid "Removes a daily interval such as lunch from bookable time."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:112
+msgid "Global booking timing rules"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:112
+msgid "Add preparation time and control how late customers may change bookings."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:112
+msgid "WPBookingly → Settings → General"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:113
+msgid "Buffer time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:113
+msgid "Adds protected time around appointments so bookings are not placed too close together."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:114
+msgid "Cancellation lead time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:114
+msgid "Minimum notice required before a customer can cancel."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:115
+msgid "Reschedule lead time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:115
+msgid "Minimum notice required before a customer can move a booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:116
+msgid "Booked order statuses"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:116
+msgid "WooCommerce statuses counted as reserving capacity."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:116
+msgid "Include only statuses that truly represent a confirmed or held booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:120
+msgid "Pricing, Tax & Discounts"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:120
+msgid "Explain the total clearly and control tax and repeating-booking incentives."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:121
+msgid "Tax settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:121
+msgid "Apply a percentage tax to a service when required."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:121
+msgid "Edit Service → Tax Settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:122
+msgid "Enable tax"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:122
+msgid "Turns tax calculation on for this service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:123
+msgid "Tax class"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:123
+msgid "Associates the service with the available tax category."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:124
+msgid "Tax rate"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:124
+msgid "Percentage added according to the configured calculation."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:124
+msgid "Confirm local tax requirements with a qualified adviser."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:126
+msgid "Recurring bookings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:126
+msgid "Allow a customer to reserve a repeated series instead of one appointment."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:126
+msgid "Edit Service → Recurring Booking"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:127
+msgid "Recurring types"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:127
+msgid "Permitted patterns: daily, weekly, bi-weekly, or monthly."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:128
+msgid "Maximum recurring count"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:128
+msgid "Largest number of occurrences a customer may book at once."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:129
+msgid "Recurring discount"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:129
+msgid "Percentage incentive applied to a repeating series."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:133
+#: Frontend/MPWPB_Static_Template.php:37
+msgid "Staff"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:133
+msgid "Create team members, assign work, and give each person a realistic schedule."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:134
+msgid "Staff profiles and service assignment"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:134
+msgid "Connect WordPress users to the services they perform."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:134
+msgid "WPBookingly → Staff Members"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:135
+msgid "Existing user"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:135
+msgid "Links the staff profile to an existing WordPress account."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:136
+msgid "Username and password"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:136
+msgid "Creates login credentials when making a new staff account."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:137
+msgid "Email, first name, last name"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:137
+msgid "Contact and identity details used for the staff profile."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:138
+msgid "Profile image"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:138
+msgid "Picture displayed for the staff member where the selected layout supports it."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:139
+msgid "Assigned services"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:139
+msgid "Limits the services for which this staff member can be selected."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:140
+msgid "Holiday behavior"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:140
+msgid "Controls whether staff-specific unavailable dates modify booking availability."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:142
+msgid "Staff availability and dashboard"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:142
+msgid "Set individual hours and manage appointments without changing the service schedule."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:142
+msgid "WPBookingly → Staff Members → Edit; staff users open their dashboard"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:143
+msgid "Date type and active range"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:143
+msgid "Defines the staff member’s repeating or date-specific availability."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:144
+msgid "Off days and dates"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:144
+msgid "Blocks personal leave and other staff-only absences."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:145
+msgid "Weekday hours and breaks"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:145
+msgid "Sets personal working and break times."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:146
+msgid "Appointment filters"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:146
+msgid "Finds bookings by date, service, or status in the staff dashboard."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:147
+msgid "Reschedule date and time"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:147
+msgid "Moves an eligible appointment to another available slot."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:148
+msgid "Profile contact and preferences"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:148
+msgid "Lets staff maintain name, email, phone, address, city, password, and working preferences."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:152
+msgid "Booking Experience"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:152
+msgid "Understand the customer journey and the controls that affect it."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:153
+msgid "Selection and customer dashboard"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:153
+msgid "Control how customers choose and later manage bookings."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:153
+msgid "Edit Service and the customer account/dashboard pages"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:154
+msgid "Multiple categories"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:154
+msgid "Shows several category groups in one booking flow."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:155
+msgid "Multiple services"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:155
+msgid "Allows several compatible choices in one booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:156
+msgid "Sticky booking widget"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:156
+msgid "Keeps the booking panel visible while a customer scrolls on supported layouts."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:157
+msgid "Single-page checkout"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:157
+msgid "Keeps supported selection and checkout steps together for a shorter journey."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:158
+msgid "Cancel / reschedule"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:158
+msgid "Customer actions are allowed only when status and lead-time rules permit them."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:159
+msgid "Waiting list"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:159
+msgid "The codebase contains waiting-list settings, but the current service-settings tab is not exposed; do not rely on it until a reachable control is provided."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:163
+msgid "Payments & Checkout"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:163
+msgid "Choose a checkout route and understand payment-related settings."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:164
+msgid "WooCommerce and payment mode"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:164
+msgid "Choose the order system that matches your site."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:164
+msgid "WPBookingly → Settings → Payment Settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:165
+msgid "WooCommerce payment mode"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:165
+msgid "Sends bookings through WooCommerce checkout, gateways, taxes, emails, and order management."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:165
+msgid "Use this when your site already relies on WooCommerce gateways or order workflows."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:166
+msgid "Custom/native payment mode"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:166
+msgid "Uses WPBookingly’s native checkout, with no WooCommerce required. Offline Payment is included free; the Stripe and PayPal gateways require Pro."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:167
+msgid "Checkout field controls"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:167
+msgid "WooCommerce billing, shipping, account, and order field visibility follows the available checkout settings screen."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:169
+msgid "Partial payment"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:169
+msgid "Collect a deposit first and leave a recorded balance for later payment."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:169
+msgid "WPBookingly → Settings → Payment Settings → Partial Payment"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:170
+msgid "Enable partial payment"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:170
+msgid "Allows an initial amount smaller than the full booking total."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:171
+msgid "Deposit type"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:171
+msgid "Chooses whether the first payment is a percentage or fixed amount where offered."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:172
+msgid "Deposit amount"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:172
+msgid "Defines the amount collected during initial checkout."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:173
+msgid "Balance payment"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:173
+msgid "The remaining amount must be collected and recorded through the supported order/customer workflow."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:177
+msgid "Create controlled promotions without unintentionally discounting every booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:178
+msgid "Every coupon setting"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:178
+msgid "Define the offer, eligibility, schedule, staff, and usage limits."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:178
+msgid "WPBookingly → Coupons → Add New or Edit"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:179
+msgid "Coupon name and status"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:179
+msgid "Internal campaign name and whether the coupon is active or draft."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:180
+#: Frontend/MPWPB_Coupon_Frontend.php:233
+#: Frontend/MPWPB_Coupon_Frontend.php:338
+#: Frontend/MPWPB_Native_Checkout.php:343
+msgid "Coupon code"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:180
+msgid "The exact code customers enter; use a short memorable value."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:181
+msgid "Internal explanation of the promotion."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:182
+msgid "Start and expiry date"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:182
+msgid "Limits the calendar period in which the code can be used."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:183
+msgid "Discount type and value"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:183
+msgid "Chooses a percentage or fixed reduction and its amount."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:184
+msgid "Maximum discount"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:184
+msgid "Caps a percentage discount where this control is displayed."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:185
+msgid "Service scope"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:185
+msgid "Applies the code to all services or only selected services."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:186
+msgid "Minimum / maximum spend"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:186
+msgid "Requires the booking total to fall inside an allowed range."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:187
+msgid "Individual use / sale restrictions"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:187
+msgid "Prevents incompatible promotion combinations where supported."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:188
+msgid "Booking-day restriction"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:188
+msgid "Restricts the weekday on which the booked service occurs."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:189
+msgid "Date mode and dates"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:189
+msgid "Includes or excludes specific booking dates."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:190
+msgid "Time mode, bucket, and range"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:190
+msgid "Limits coupon use to selected times of day or a custom time range."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:191
+msgid "Staff scope and selected staff"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:191
+msgid "Restricts the offer to bookings handled by particular staff members."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:192
+msgid "Total usage limit"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:192
+msgid "Maximum successful uses across all customers."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:193
+msgid "Per-customer usage limit"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:193
+msgid "Maximum successful uses for one customer."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:197
+msgid "Reviews & Follow-up"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:197
+msgid "Manage feedback and confirm customers receive the expected communication."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:198
+msgid "Reviews and email follow-up"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:198
+msgid "Moderate feedback and diagnose missing customer messages."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:198
+msgid "WPBookingly → Reviews; order and WordPress email settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:199
+msgid "Review filters"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:199
+msgid "Narrow feedback by available service, rating, or moderation state."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:200
+msgid "Moderation actions"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:200
+msgid "Approve, hide, or otherwise manage feedback using the controls displayed."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:201
+msgid "Email delivery"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:201
+msgid "Booking messages depend on the chosen payment flow, WordPress mail delivery, and valid recipient addresses."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:201
+msgid "Use an SMTP/mail logging plugin when messages do not arrive consistently."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:205
+msgid "Analytics & CSV"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:205
+msgid "Read booking performance and export results for reporting."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:206
+msgid "Dashboard filters, metrics, charts, and export"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:206
+msgid "Turn booking records into useful operational information."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:206
+msgid "WPBookingly → Analytics"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:207
+msgid "Date range"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:207
+msgid "Limits calculations to the selected booking or reporting period."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:208
+msgid "Service filter"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:208
+msgid "Shows results for all services or one selected service."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:209
+msgid "Status filter"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:209
+msgid "Includes only records in the chosen booking/order state."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:210
+msgid "Summary metrics and charts"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:210
+msgid "Present booking volume, revenue, service, and trend information available in the dashboard."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:211
+msgid "CSV export"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:211
+msgid "Downloads the filtered data for spreadsheets and external reporting."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:215
+msgid "GDPR & Privacy"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:215
+msgid "Request consent clearly and handle customer privacy requests responsibly."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:216
+msgid "Privacy and consent settings"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:216
+msgid "Configure the customer-facing privacy messages."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:216
+msgid "WPBookingly → Settings → GDPR / Privacy"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:217
+msgid "Enable GDPR"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:217
+msgid "Turns the plugin’s privacy/consent presentation on."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:218
+msgid "Cookie banner message"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:218
+msgid "Explains why the site uses relevant cookies."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:219
+msgid "Accept and reject text"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:219
+msgid "Labels the customer’s cookie choices."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:220
+msgid "Privacy policy page"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:220
+msgid "Links customers to the site’s full privacy policy."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:221
+msgid "Privacy consent text"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:221
+msgid "Explains agreement to the privacy policy during booking."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:222
+msgid "Data consent text"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:222
+msgid "Explains why booking details are collected and processed."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:223
+msgid "Privacy requests"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:223
+msgid "Use the available request screen to locate and track supported customer privacy requests."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:227
+msgid "Labels, URLs & Styling"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:227
+msgid "Match the booking interface to your language, brand, and WordPress structure."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:228
+msgid "All global labels and appearance fields"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:228
+msgid "Customize terminology, permalinks, formats, media behavior, and colors."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:228
+msgid "WPBookingly → Settings → General / Display / Style"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:229
+msgid "Service label, slug, and icon"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:229
+msgid "Changes the admin/public service name, URL base, and associated icon."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:229
+msgid "After changing a slug, save WordPress Permalinks once."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:230
+msgid "Category label and slug"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:230
+msgid "Changes category wording and its URL base."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:231
+msgid "Organizer label and slug"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:231
+msgid "Changes staff/organizer terminology and URL base where used."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:232
+msgid "Category, subcategory, and service text"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:232
+msgid "Replaces customer-facing selection instructions."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:233
+msgid "Disable block editor"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:233
+msgid "Uses the plugin’s intended classic/custom service editing experience."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:234
+msgid "Full and short date format"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:234
+msgid "Controls how dates appear in long and compact contexts."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:235
+msgid "24-hour time format"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:235
+msgid "Switches supported time displays between 24-hour and 12-hour notation."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:236
+msgid "Slider type and style"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:236
+msgid "Chooses the available gallery/slider behavior and visual treatment."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:237
+msgid "Indicator visibility and type"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:237
+msgid "Controls navigation indicators shown with service media."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:238
+msgid "Showcase visibility and position"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:238
+msgid "Controls whether and where the media showcase is presented."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:239
+msgid "Popup image/icon indicator"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:239
+msgid "Chooses cues used for opening media in a popup."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:240
+msgid "Theme and alternate color"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:240
+msgid "Applies the primary and supporting brand colors to supported booking components."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:241
+#: Admin/MPWPB_Settings_Global.php:105
+#: Admin/MPWPB_Settings_Global.php:562
+msgid "Custom CSS"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:241
+msgid "Adds advanced site-specific style overrides."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:241
+msgid "Use narrowly scoped selectors and keep a copy before changing themes."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:245
+msgid "Troubleshooting"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:245
+msgid "Resolve the most common setup problems in a safe order."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:246
+msgid "No slots, checkout, email, 404, and staff issues"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:246
+msgid "Use these checks before changing or reinstalling anything."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:246
+msgid "WPBookingly → Status, Settings, Service editor, and Staff Members"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:247
+msgid "No available slots"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:247
+msgid "Check future dates, weekday hours, breaks, off dates, slot length, capacity, buffer time, staff assignment, and booked statuses."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:248
+msgid "Checkout or payment fails"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:248
+msgid "Confirm the selected payment mode, WooCommerce pages/gateways when used, currency, HTTPS, and gateway credentials for enabled native gateways."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:249
+msgid "Emails do not arrive"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:249
+msgid "Verify recipient addresses, order status, WordPress mail delivery, spam folders, and SMTP logs."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:250
+msgid "Service page returns 404"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:250
+msgid "Open Settings → Permalinks and save once, especially after changing a service or taxonomy slug."
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:251
+msgid "Staff member not selectable"
+msgstr ""
+
+#: Admin/MPWPB_Help_Guide_Content.php:251
+msgid "Confirm the user is assigned to the service and has availability overlapping the service date and time."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:47
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:857
+msgid "Payment settings saved."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:62
+#: Admin/MPWPB_Native_Checkout_Settings.php:89
+msgid "WooCommerce is not active."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:66
+#: Admin/MPWPB_Native_Checkout_Settings.php:93
+msgid "Unknown payment gateway."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:101
+msgid "Settings saved."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:108
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:297
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:435
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:324
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:421
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:443
+#: Frontend/MPWPB_Native_Checkout.php:454
+#: Frontend/MPWPB_Native_Checkout.php:751
+msgid "Payment Method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:114
+msgid "Partial Payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:120
+msgid "Currency Settings"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:129
+msgid "Currency Code"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:130
+msgid "ISO currency code charged through Stripe/PayPal. This is separate from the display symbol below — Stripe/PayPal require a real currency code (a \"$\" alone is ambiguous between USD/CAD/AUD/etc.)."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:165
+msgid "Currency Symbol"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:166
+msgid "Used to format all booking prices when Payment Method is Custom."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:172
+msgid "Currency Position"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:175
+msgid "Left ($99.00)"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:176
+msgid "Right (99.00$)"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:177
+msgid "Left with space ($ 99.00)"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:178
+msgid "Right with space (99.00 $)"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:184
+msgid "Number of Decimals"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:192
+msgid "Decimal Separator"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:198
+msgid "Thousand Separator"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:235
+#: Frontend/MPWPB_Native_Checkout.php:95
+msgid "PayPal"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:241
+#: Frontend/MPWPB_Native_Checkout.php:92
+msgid "Credit/Debit Card (Stripe)"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:247
+#: Frontend/MPWPB_Native_Checkout.php:89
+msgid "Offline Payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:255
+#: Admin/MPWPB_Native_Checkout_Settings.php:436
+#: Admin/MPWPB_Quick_Setup.php:102
+#: Admin/MPWPB_Status.php:169
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:420
+msgid "WooCommerce"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:256
+#: Admin/MPWPB_Native_Checkout_Settings.php:437
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:421
+msgid "Custom Payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:259
+#: Admin/MPWPB_Native_Checkout_Settings.php:270
+msgid "Only one checkout payment method can be active at a time."
+msgstr ""
+
+#. translators: 1: current payment method, 2: new payment method
+#: Admin/MPWPB_Native_Checkout_Settings.php:264
+#: Admin/MPWPB_Native_Checkout_Settings.php:275
+#, php-format
+msgid "%1$s will be turned off, and %2$s will become active."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:282
+msgid "Payment method change"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:283
+msgid "Current method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:284
+msgid "New method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:443
+msgid "Close dialog"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:447
+msgid "Payment configuration"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:448
+msgid "Only One Payment Method Allowed"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:453
+msgid "Your gateway settings remain saved."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:455
+msgid "Keep Current"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:456
+msgid "Switch Method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:465
+msgid "Notice: WooCommerce is Not Activated"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:466
+msgid "To use WooCommerce as your payment method, you must install and activate WooCommerce."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:468
+msgid "Activate Now"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:468
+msgid "Install & Activate Now"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:478
+msgid "Enable WooCommerce Payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:479
+msgid "If enabled, WooCommerce payment gateway will be used for checkout."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:489
+msgid "WooCommerce Payment Methods"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:495
+msgid "Open in WooCommerce"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:510
+#: Admin/MPWPB_Native_Checkout_Settings.php:964
+msgid "ENABLED"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:510
+#: Admin/MPWPB_Native_Checkout_Settings.php:964
+msgid "DISABLED"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:512
+#: Admin/MPWPB_Native_Checkout_Settings.php:671
+msgid "Configure"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:520
+msgid "Save Changes"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:530
+msgid "Additional Settings"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:536
+msgid "After Adding to Cart, Redirect to"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:537
+msgid "Select where to redirect after adding a booking to cart."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:540
+#: Frontend/MPWPB_Native_Checkout.php:721
+#: Frontend/MPWPB_Static_Template.php:39
+msgid "Checkout"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:541
+msgid "Cart"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:546
+msgid "After Confirming the Order, Redirect To"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:547
+msgid "Select where to redirect after the order is confirmed."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:550
+msgid "WooCommerce Default"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:551
+msgid "Plugin Thank You Page"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:556
+msgid "Require Account Login"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:561
+msgid "Require login to book a service."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:566
+msgid "Show Billing Info"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:571
+msgid "Show billing info on the WooCommerce checkout page."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:576
+msgid "Disable WooCommerce Customer Emails"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:577
+msgid "Bookings are sold through a hidden WooCommerce product, so WooCommerce mails customers its standard \"order processing / order complete\" notifications, which read like shipping confirmations. Turn this on to stop those automatic emails for orders that only contain bookings — the booking confirmation email with the PDF ticket (Settings → Email) is sent instead. Admin \"New order\" notifications, manually sent invoices and customer notes are never affected."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:582
+msgid "Do not send WooCommerce order emails to booking customers."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:587
+msgid "Confirm Booking Based on Payment Status"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:588
+msgid "Select the order statuses that will trigger booking confirmation."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:591
+msgid "Pending payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:591
+#: Admin/MPWPB_Settings_Global.php:267
+msgid "Processing"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:591
+msgid "On hold"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:591
+#: Admin/MPWPB_Native_Order_List.php:289
+#: Admin/MPWPB_Settings_Global.php:268
+msgid "Completed"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:608
+msgid "Enable Custom Payment Method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:612
+msgid "If enabled, the custom payment gateways below (PayPal, Stripe, Offline) will be used for checkout."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:614
+msgid "If enabled, bookings are taken through the built-in checkout instead of WooCommerce. Offline Payment is included free; PayPal and Stripe require Pro."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:656
+msgid "Unlock with Pro"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:669
+#: Admin/MPWPB_Native_Checkout_Settings.php:1021
+#: Admin/MPWPB_Status.php:127
+msgid "Enabled"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:669
+#: Admin/MPWPB_Native_Checkout_Settings.php:1023
+#: Admin/MPWPB_Status.php:127
+msgid "Disabled"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:677
+msgid "Enable this payment method"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:685
+msgid "Instructions shown to the customer at checkout"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:687
+msgid "Please pay via bank transfer. We will confirm your booking once payment is received."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:690
+msgid "These instructions are shown during checkout and included with the booking payment details."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:696
+msgid "Test"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:697
+#: Admin/MPWPB_Native_Checkout_Settings.php:736
+msgid "Live"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:702
+msgid "Publishable Key"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:708
+msgid "Secret Key"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:714
+msgid "Webhook Secret"
+msgstr ""
+
+#. translators: %s: Stripe webhook endpoint URL
+#: Admin/MPWPB_Native_Checkout_Settings.php:724
+#, php-format
+msgid "Customers pay on a Stripe-hosted page and are redirected back once done. Also add this URL as a webhook endpoint in your Stripe Dashboard (Developers → Webhooks) listening for the <code>checkout.session.completed</code> event — it confirms payment even if the customer closes the tab before returning: <code>%s</code>"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:735
+msgid "Sandbox"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:741
+msgid "Client ID"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:747
+msgid "Client Secret"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:752
+msgid "Customers approve payment on a PayPal-hosted page and are redirected back once done. Use your PayPal app's Client ID/Secret for the mode selected above (sandbox app credentials while testing, live app credentials when ready to accept real payments)."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:759
+msgid "Booking Confirmation Page"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:760
+msgid "Select a page with the [mpwpb_booking_confirmation] shortcode. After booking, customers are redirected here instead of the default confirmation page."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:767
+msgid "— Default —"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1007
+msgid "Saved."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1009
+#: Admin/MPWPB_Native_Checkout_Settings.php:1039
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:858
+msgid "Something went wrong."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1012
+#: Admin/MPWPB_Native_Checkout_Settings.php:1043
+msgid "Request failed."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1031
+msgid "Please wait…"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1070
+msgid "Enable Partial Payment"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1071
+msgid "Let customers pay a deposit at checkout and the remaining balance later from My Account."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1081
+msgid "Deposit Type"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1082
+msgid "Charge a fixed amount, or a percentage of the booking total, as the deposit."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1085
+msgid "Percentage"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1086
+#: Admin/settings/Happy_Hours.php:125
+msgid "Fixed Amount"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1091
+msgid "Deposit Percentage"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1097
+msgid "Deposit Fixed Amount"
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1129
+msgid "WooCommerce is already active."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1136
+msgid "WooCommerce activated."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1152
+msgid "Could not install WooCommerce."
+msgstr ""
+
+#: Admin/MPWPB_Native_Checkout_Settings.php:1158
+msgid "WooCommerce installed and activated."
+msgstr ""
+
+#. translators: %s: settings page URL
+#: Admin/MPWPB_Native_Checkout_Settings.php:1183
+#, php-format
+msgid "<strong>Service Booking Manager:</strong> No payment method is currently configured. <a href=\"%s\">Configure a payment method</a> to accept bookings."
+msgstr ""
+
+#: Admin/MPWPB_Native_Order.php:22
+msgid "Native Bookings Orders"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order.php:42
+msgid "Native Booking Order"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:48
+#: Admin/MPWPB_Native_Order_List.php:49
+#: Admin/MPWPB_Native_Order_List.php:79
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:89
+msgid "Orders"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:63
+msgid "You do not have permission to view this page."
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:80
+msgid "A read-only overview of bookings placed through the built-in (non-WooCommerce) checkout. Unlock statistics, filters, order details and status management with Pro."
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:82
+#: Admin/MPWPB_Pro_Upsell_Notice.php:111
+msgid "Upgrade to Pro"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:89
+msgid "Total Orders"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:90
+msgid "Total Revenue"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:94
+msgid "Live statistics are a Pro feature"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:101
+msgid "Filter Orders"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:104
+msgid "Search"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:104
+msgid "Name, email or #ID…"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:105
+#: Admin/MPWPB_Reviews_Admin.php:182
+#: Admin/MPWPB_Staff_DashBoard.php:1191
+msgid "All Statuses"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:107
+msgid "Date From"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:112
+msgid "Filtering & search are a Pro feature"
+msgstr ""
+
+#. translators: %d: number of orders
+#. translators: %d: number of displayed orders
+#: Admin/MPWPB_Native_Order_List.php:122
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:254
+#, php-format
+msgid "%d order"
+msgid_plural "%d orders"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Admin/MPWPB_Native_Order_List.php:135
+msgid "Service & Slot"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:136
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:420
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:442
+#: Frontend/MPWPB_Native_Checkout.php:370
+msgid "Total"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:138
+msgid "Placed"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:139
+#: Admin/MPWPB_Reviews_Admin.php:226
+#: Admin/MPWPB_Reviews_Admin.php:415
+#: Admin/MPWPB_Staff_DashBoard.php:378
+#: Admin/MPWPB_Staff_DashBoard.php:1048
+#: Admin/MPWPB_Staff_DashBoard.php:1340
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:422
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:444
+#: Frontend/MPWPB_User_Dashboard.php:242
+#: templates/layout/coupon_list.php:170
+#: templates/layout/service_list.php:318
+msgid "Actions"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:147
+msgid "No orders yet."
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:148
+msgid "When a customer completes the booking checkout, their order will appear here."
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:167
+msgid "Order details are available in Pro"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:168
+msgid "Changing status is available in Pro"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:181
+msgid "Prev"
+msgstr ""
+
+#. translators: 1: current page number, 2: total number of pages
+#: Admin/MPWPB_Native_Order_List.php:187
+#, php-format
+msgid "Page %1$d of %2$d"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:194
+#: Admin/MPWPB_Quick_Setup.php:82
+msgid "Next"
+msgstr ""
+
+#. translators: %s: formatted time
+#: Admin/MPWPB_Native_Order_List.php:267
+#, php-format
+msgid "M j, Y \\@ %s"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:288
+msgid "Confirmed"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:290
+#: Admin/MPWPB_Native_Order_List.php:291
+msgid "Cancelled"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:292
+msgid "Refunded"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:293
+#: Admin/MPWPB_Settings_Global.php:265
+msgid "On Hold"
+msgstr ""
+
+#: Admin/MPWPB_Native_Order_List.php:294
+msgid "Failed"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:31
+#: Admin/MPWPB_Pro_Locked_Menus.php:32
+#: Admin/MPWPB_Pro_Locked_Menus.php:106
+msgid "Pro Features"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:43
+msgid "Order List"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:44
+msgid "A dedicated, filterable list of every booking order, separate from WooCommerce's own Orders screen."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:48
+#: Admin/MPWPB_Pro_Upsell_Notice.php:85
+msgid "Service Queue"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:49
+msgid "A live queue view of upcoming and in-progress appointments across every service."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:53
+#: Admin/MPWPB_Pro_Upsell_Notice.php:86
+msgid "Service Calendar"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:54
+msgid "A calendar view of every booking across all services and staff, at a glance."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:58
+msgid "Backend Order"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:59
+msgid "Create a booking manually from the admin on behalf of a customer -- phone bookings, walk-ins, or any order placed for them rather than by them."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:63
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:130
+#: Admin/settings/Happy_Hours.php:53
+msgid "Happy Hours Pricing"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:64
+msgid "Automatic time-of-day discounts -- give customers a lower price when their appointment falls inside a set window."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:68
+msgid "Google Calendar"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:69
+msgid "Every completed booking is pushed straight to a connected Google Calendar as a real event."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:73
+msgid "Google Sheets Sync"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:74
+msgid "Keep a live, always up-to-date spreadsheet of every booking, synced automatically to Google Sheets."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:78
+msgid "Two-Factor Authentication"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:79
+msgid "Add an authenticator-app second login step, with backup codes, to admin and staff accounts."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:83
+msgid "Booking Verification"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:84
+msgid "Confirm a booking is real before it's placed -- send the customer a phone or email verification code at checkout."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:88
+msgid "Custom Payment (PayPal & Stripe)"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:89
+msgid "Take bookings without WooCommerce -- a built-in checkout that accepts payment directly via PayPal and Stripe."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:93
+msgid "PDF Ticketing"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:94
+msgid "Generate a downloadable PDF ticket for every booking, with a one-click Download Ticket button on the confirmation page."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:98
+msgid "Automated Email Confirmation"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:99
+msgid "Automatically email the customer a booking confirmation, with their PDF ticket attached, the moment their order completes."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Locked_Menus.php:107
+#: Admin/settings/Happy_Hours.php:62
+msgid "Requires the service-booking-manager-pro plugin to be installed and activated."
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:84
+msgid "Advanced Order List"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:87
+msgid "Backend Orders"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:88
+msgid "PDF Tickets"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:89
+msgid "Stripe & PayPal"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:90
+msgid "Google Calendar & Sheets"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:96
+msgid "Dismiss this notice"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:96
+#: Admin/MPWPB_Reviews_Admin.php:1134
+msgid "Dismiss"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:101
+msgid "Unlock the full booking suite"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:102
+msgid "You're on the free plan. Upgrade to Pro to manage every order in one place and unlock the complete toolkit:"
+msgstr ""
+
+#: Admin/MPWPB_Pro_Upsell_Notice.php:114
+msgid "See all Pro features"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:15
+msgid "Quick Setup"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:52
+msgid "Welcome"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:66
+msgid "Done"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:78
+msgid "Previous"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:96
+#: inc/MPWPB_Woo_Installer.php:114
+msgid "Service Booking Manager"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:97
+msgid "Welcome! Choose how you want to accept payments for bookings, then continue."
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:107
+msgid "Custom Payment Method (Stripe / PayPal / Offline)"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:111
+msgid "You can configure Stripe, PayPal, and Offline payment, and change this at any time from Settings > Payment Method."
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:123
+msgid "General settings"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:124
+msgid "Choose some general option."
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:127
+msgid "Service Booking Manager Label:"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:132
+msgid "It will change the Service Booking Manager post type label on the entire plugin."
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:136
+msgid "Service Booking Manager Slug:"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:141
+msgid "It will change the Service Booking Manager slug on the entire plugin. Remember after changing this slug you need to flush permalinks. Just go to Settings->Permalinks hit the Save Settings button"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:151
+msgid "Finalize Setup"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:152
+msgid "You are about to Finish & Save service-booking-manager For Woocommerce Plugin setup process"
+msgstr ""
+
+#: Admin/MPWPB_Quick_Setup.php:155
+msgid "Finish & Save"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:81
+msgid "Service Reviews"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:82
+msgid "Manage customer feedback, request reviews from past customers, and configure the request email."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:96
+msgid "Review List"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:97
+msgid "Review Requested"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:98
+msgid "Review Settings"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:168
+#: Admin/MPWPB_Reviews_Admin.php:372
+msgid "Service Type"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:180
+msgid "Approval Status"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:189
+#: Admin/MPWPB_Reviews_Admin.php:222
+msgid "Rating"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:191
+msgid "Any Rating"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:194
+msgid "Stars"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:210
+msgid "No reviews found."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:219
+msgid "ID"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:223
+msgid "Review"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:233
+#: Admin/MPWPB_Reviews_Admin.php:422
+#: Admin/MPWPB_Reviews_Admin.php:612
+msgid "Unknown Service"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:281
+#: Admin/MPWPB_Reviews_Admin.php:283
+#: Admin/MPWPB_Staff_DashBoard.php:1389
+msgid "View"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:292
+#: Admin/MPWPB_Reviews_Admin.php:294
+msgid "Mark Pending"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:298
+#: Admin/MPWPB_Reviews_Admin.php:300
+msgid "Delete"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:298
+msgid "Are you sure you want to delete this review?"
+msgstr ""
+
+#. translators: 1: first row number, 2: last row number, 3: total review count
+#: Admin/MPWPB_Reviews_Admin.php:313
+#, php-format
+msgid "Showing %1$d-%2$d of %3$d reviews"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:384
+#: Admin/MPWPB_Reviews_Admin.php:414
+msgid "Request Status"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:387
+#: Admin/MPWPB_Reviews_Admin.php:445
+msgid "Not Sent"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:388
+msgid "Sent"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:402
+msgid "No bookings are currently eligible for a review request."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:413
+msgid "Booking Date"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:428
+msgid "Guest"
+msgstr ""
+
+#. translators: %s: date the review request was sent
+#: Admin/MPWPB_Reviews_Admin.php:440
+#, php-format
+msgid "Sent %s"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:450
+msgid "Resend"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:450
+#: Admin/MPWPB_Staff_DashBoard.php:1253
+msgid "Send Request"
+msgstr ""
+
+#. translators: 1: first row number, 2: last row number, 3: total booking count
+#: Admin/MPWPB_Reviews_Admin.php:463
+#, php-format
+msgid "Showing %1$d-%2$d of %3$d bookings"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:511
+msgid "Automation"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:512
+msgid "Let the plugin email past customers a review request on your behalf."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:518
+msgid "Automatically send review requests"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:519
+msgid "When enabled, a daily background task emails eligible customers automatically. Manually sending from the Review Requested tab always works regardless of this setting."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:529
+msgid "Send after"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:530
+msgid "Number of days after the service date before the automatic request is sent."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:534
+msgid "days"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:543
+msgid "Request Email"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:544
+msgid "The message customers receive when you ask them for a review."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:549
+msgid "Email Subject"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:554
+msgid "Email Body"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:565
+msgid "Insert placeholder:"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:574
+msgid "Save Settings"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:592
+#: Admin/MPWPB_Reviews_Admin.php:633
+#: Admin/MPWPB_Reviews_Admin.php:690
+#: Admin/MPWPB_Reviews_Admin.php:716
+#: Admin/MPWPB_Reviews_Admin.php:1076
+msgid "You do not have permission to perform this action"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:697
+#: Admin/MPWPB_Reviews_Admin.php:722
+msgid "Invalid request"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:703
+msgid "Review status updated successfully"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:705
+msgid "Failed to update review status"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:728
+msgid "Review deleted successfully"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:730
+msgid "Failed to delete review"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:769
+msgid "Please log in to leave a review."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:778
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:733
+#: Frontend/MPWPB_User_Dashboard.php:1056
+msgid "Invalid service."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:781
+msgid "Please select a rating between 1 and 5 stars."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:784
+msgid "Please write a short review."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:790
+msgid "You can only review services you have booked."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:814
+msgid "Thank you! Your review has been submitted and is awaiting approval."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:959
+#: Admin/MPWPB_Status.php:63
+#: mp_global/class/MPWPB_Booking_Notes.php:201
+msgid "Unknown"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:987
+msgid "This booking has no registered customer account, so they cannot actually submit a review."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:989
+#: Admin/MPWPB_Reviews_Admin.php:1026
+msgid "No valid billing email on file for this booking."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1021
+msgid "Subject and message cannot be empty."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1031
+msgid "The email could not be sent. Please try again."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1035
+msgid "Review request sent."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1122
+msgid "Review request sent to the customer."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1123
+msgid "The review request could not be sent. Please check that the booking has a valid customer email and that your site is able to send email."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1124
+msgid "Review settings saved."
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1145
+msgid "How was your {service_name} experience?"
+msgstr ""
+
+#: Admin/MPWPB_Reviews_Admin.php:1152
+msgid ""
+"Hi {customer_name},\n"
+"\n"
+"Thank you for booking {service_name} on {booking_date}. We'd love to hear how it went!\n"
+"\n"
+"Please take a moment to leave a review:\n"
+"{review_link}\n"
+"\n"
+"Thanks,\n"
+"{site_name}"
+msgstr ""
+
+#: Admin/MPWPB_Service_List.php:38
+msgid "Invalid request (missing or invalid nonce)."
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:19
+msgid " Information Settings : "
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:31
+msgid "General Info"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:34
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:121
+#: Frontend/MPWPB_Static_Template.php:34
+msgid "Date & Time"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:37
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:100
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:113
+msgid "Services & Pricing"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:40
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:114
+#: Frontend/MPWPB_Stripe_Gateway.php:96
+msgid "Extra Service"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:43
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:128
+#: Frontend/MPWPB_Static_Template.php:168
+msgid "FAQ"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:46
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:106
+#: Admin/settings/Service_Details.php:90
+#: Admin/settings/Service_Details.php:91
+#: Frontend/MPWPB_Static_Template.php:332
+msgid "Service Details"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:49
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:81
+#: Admin/settings/Service_Settings.php:40
+msgid "Service Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:54
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:137
+msgid "Staff Member"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:248
+msgid "By default Service Details  is OFF but you can keep it ON by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:249
+msgid "By default Service Duration  is ON but you can keep it OFF by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:250
+msgid "By default Multi Select  is OFF but you can keep it ON by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:251
+msgid "By default Staff  is OFF but you can keep it ON by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:252
+msgid "By default extra service  is OFF but you can keep it ON by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:254
+msgid "By default staff  is OFF but you can keep it ON by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:256
+msgid "By default slider is ON but you can keep it off by switching this option"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:257
+msgid "Please upload images for gallery"
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:259
+msgid "Copty this shortcode and paste any post or page."
+msgstr ""
+
+#: Admin/MPWPB_Settings.php:260
+#: Admin/MPWPB_Settings.php:261
+#: Admin/MPWPB_Settings.php:262
+#: Admin/MPWPB_Settings.php:263
+msgid "Date & time settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:26
+msgid " Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:47
+#: Admin/MPWPB_Settings_Global.php:84
+msgid "Global Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:79
+#: Admin/MPWPB_Staffs.php:265
+#: Admin/MPWPB_Staff_Members.php:300
+msgid "General Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:95
+msgid "Slider Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:100
+msgid "Style Settings"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:110
+#: Admin/MPWPB_Settings_Global.php:573
+msgid "Mage-People License"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:122
+msgid "Label"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:123
+msgid "If you like to change the label in the dashboard menu, you can change it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:125
+#: inc/MPWPB_Function.php:82
+msgid "Service Booking"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:129
+msgid "Slug"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:130
+msgid "Please enter the slug name you want. The slug will be automatically sanitized and converted to URL-friendly format."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:137
+#: Admin/settings/Extra_service.php:295
+#: Admin/settings/Service.php:266
+#: Admin/settings/Service.php:365
+#: mp_global/class/MPWPB_Select_Icon_image.php:161
+msgid "Icon"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:138
+msgid "If you want to change the  icon in the dashboard menu, you can change it from here, and the Dashboard icon only supports the Dashicons, So please go to "
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:138
+msgid "Dashicons Library."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:138
+msgid "and copy your icon code and paste it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:144
+msgid "Category Label"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:145
+msgid "If you want to change the  category label in the dashboard menu, you can change it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:151
+msgid "Category Slug"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:152
+msgid "Please enter the slug name you want for  category. Remember after change this slug you need to flush permalink, Just go to  "
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:152
+#: Admin/MPWPB_Settings_Global.php:167
+msgid "Settings-> Permalinks"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:152
+#: Admin/MPWPB_Settings_Global.php:167
+msgid "hit the Save Settings button."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:159
+msgid "Organizer Label"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:160
+msgid "If you want to change the   category label in the dashboard menu you can change here"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:166
+msgid "Organizer Slug"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:167
+msgid "Please enter the slug name you want for the   organizer. Remember, after changing this slug, you need to flush the permalinks. Just go to "
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:174
+msgid "Product Category Text"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:175
+msgid "If you want to change the  Product Category Text, you can change it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:181
+msgid "Product Sub-Category Text"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:182
+msgid "If you want to change the  Product Sub-Category Text, you can change it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:184
+#: inc/MPWPB_Function.php:110
+msgid "Sub-Category"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:188
+msgid "Product ServiceText"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:189
+msgid "If you want to change the  Product Service Text, you can change it here."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:195
+msgid "Disable single page checkout"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:196
+msgid "If you want to disable single page checkout, please select Yes.That means active woocommerce checkout page active"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:200
+#: Admin/MPWPB_Settings_Global.php:238
+#: Admin/MPWPB_Settings_Global.php:251
+#: Admin/MPWPB_Settings_Global.php:348
+#: Admin/MPWPB_Status.php:160
+#: Admin/MPWPB_Status.php:171
+#: Admin/settings/Waiting_List.php:48
+#: Frontend/MPWPB_Recurring_Booking.php:290
+msgid "Yes"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:201
+#: Admin/MPWPB_Settings_Global.php:239
+#: Admin/MPWPB_Settings_Global.php:252
+#: Admin/MPWPB_Settings_Global.php:349
+#: Admin/MPWPB_Status.php:160
+#: Admin/MPWPB_Status.php:171
+#: Admin/settings/Waiting_List.php:49
+msgid "No"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:206
+msgid "Buffer Time"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:207
+msgid "Please enter here  buffer time in minute. By default is 0"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:211
+msgid "Ex:50"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:215
+msgid "Cancellation Lead Time (hours)"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:216
+msgid "Customers and staff can only cancel a booking online if it starts at least this many hours from now. Default is 24."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:220
+#: Admin/MPWPB_Settings_Global.php:229
+msgid "Ex:24"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:224
+msgid "Reschedule Lead Time (hours)"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:225
+msgid "Customers and staff can only reschedule/edit a booking online if it starts at least this many hours from now. Default is 24."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:233
+msgid "Booking widget sticky on scrolling"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:246
+msgid "Disable Block/Gutenberg Editor"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:247
+msgid "If you want to disable WordPress's new Block/Gutenberg editor, please select Yes."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:257
+msgid "Seat Booked Status"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:258
+msgid "Please Select when and which order status Seat Will be Booked/Reduced."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:273
+msgid "Date Picker Layout"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:274
+msgid "How the booking form shows available dates. \"Slider\" keeps the row of day cards, paged a few at a time. \"Full Calendar\" shows a real month grid with the month name and year, one month per page -- far easier once the booking window is long (30, 60, 90 days)."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:278
+msgid "Slider (day cards)"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:279
+msgid "Full Calendar (month grid)"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:284
+msgid "Date Picker Format"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:285
+msgid "If you want to change Date Picker Format, please select format. Default  is D d M , yy."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:305
+msgid "Date Format Without Year"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:306
+msgid "Controls compact date pickers that intentionally omit the year."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:318
+msgid "Short Date  Format"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:319
+msgid "If you want to change Short Date  Format, please select format. Default  is M , Y."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:343
+msgid "24 Hour Time Format"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:344
+msgid "Enable 24 hour time format everywhere in the plugin (frontend, PDF, email, admin order list, etc.)"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:356
+msgid "Slider Type"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:357
+msgid "Please Select Slider Type Default Slider"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:361
+msgid "Slider"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:362
+msgid "Post Thumbnail"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:367
+msgid "Slider Style"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:368
+msgid "Please Select Slider Style Default Style One"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:372
+msgid "Style One"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:373
+msgid "Style Two"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:378
+msgid "Slider Indicator Visible?"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:379
+msgid "Please Select Slider Indicator Visible or Not? Default ON"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:383
+#: Admin/MPWPB_Settings_Global.php:405
+#: Admin/MPWPB_Settings_Global.php:429
+#: Admin/MPWPB_Settings_Global.php:440
+msgid "ON"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:384
+#: Admin/MPWPB_Settings_Global.php:406
+#: Admin/MPWPB_Settings_Global.php:430
+#: Admin/MPWPB_Settings_Global.php:441
+#: Admin/MPWPB_Status.php:141
+#: Admin/MPWPB_Status.php:161
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:536
+msgid "Off"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:389
+msgid "Slider Indicator Type"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:390
+msgid "Please Select Slider Indicator Type Default Icon"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:394
+msgid "Icon Indicator"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:395
+msgid "image Indicator"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:400
+msgid "Slider Showcase Visible?"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:401
+msgid "Please Select Slider Showcase Visible or Not? Default ON"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:411
+msgid "Slider Showcase Position"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:412
+msgid "Please Select Slider Showcase Position Default Right"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:416
+msgid "At Top Position"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:417
+msgid "At Right Position"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:418
+msgid "At Bottom Position"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:419
+msgid "At Left Position"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:424
+msgid "Slider Popup Image Indicator"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:425
+msgid "Please Select Slider Popup Indicator Image ON or Off? Default ON"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:435
+msgid "Slider Popup Icon Indicator"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:436
+msgid "Please Select Slider Popup Indicator Icon ON or Off? Default ON"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:448
+msgid "Primary Color"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:449
+msgid "Select Default Theme Color"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:455
+msgid "Secondary Color"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:456
+msgid "Select Default Theme Alternate  Color that means, if background theme color then it will be text color."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:563
+msgid "Write Your Custom CSS Code Here"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:576
+msgid "Thanking you for using our Mage-People plugin. Our some plugin  free and no license is required. We have some Additional addon to enhance feature of this plugin functionality. If you have any addon you need to enter a valid license for that plugin below."
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:583
+msgid "Plugin Name"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:584
+msgid "Type"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:585
+msgid "Order No"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:586
+msgid "Expire on"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:587
+msgid "License Key"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:594
+msgid "Service Booking & Scheduling Solution | All-in-one Booking Systems"
+msgstr ""
+
+#: Admin/MPWPB_Settings_Global.php:598
+msgid "No Need"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:53
+msgid "Profile Image"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:56
+#: Admin/MPWPB_Staffs.php:61
+msgid "Upload Image"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:62
+#: Admin/MPWPB_Staff_Members.php:65
+#: mp_global/class/MPWPB_Select_Icon_image.php:156
+msgid "Remove Image"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:77
+#: Admin/MPWPB_Staffs.php:78
+#: Admin/MPWPB_Staff_Members.php:86
+#: Admin/MPWPB_Staff_Members.php:87
+msgid "Staff Lists"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:80
+#: Admin/MPWPB_Staff_Members.php:89
+msgid "Add New Staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:81
+#: Admin/MPWPB_Staff_Members.php:90
+msgid "Add/Update Staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:113
+#: Admin/MPWPB_Staff_Members.php:122
+msgid "SI."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:114
+#: Admin/MPWPB_Staff_Members.php:123
+msgid "User Image"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:115
+#: Admin/MPWPB_Staffs.php:189
+#: Admin/MPWPB_Staff_Members.php:124
+msgid "User Name"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:116
+#: Admin/MPWPB_Staff_Members.php:125
+msgid "Staff Name"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:117
+#: Admin/MPWPB_Staffs.php:197
+#: Admin/MPWPB_Staff_Members.php:126
+msgid "Staff Email"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:133
+#: Admin/MPWPB_Staff_Members.php:142
+msgid "edit Staff Details."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:136
+#: Admin/MPWPB_Staff_Members.php:145
+msgid "Remove staff."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:147
+#: Admin/MPWPB_Staff_Members.php:173
+msgid "No Staff Found!"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:154
+#: Admin/MPWPB_Staff_Members.php:180
+msgid "You have no permission to create staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:173
+#: Admin/MPWPB_Staff_Members.php:199
+msgid "Staff Information"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:176
+#: Admin/MPWPB_Staff_Members.php:209
+msgid "Select User"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:178
+#: Admin/MPWPB_Staff_Members.php:211
+msgid "Add New User"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:190
+#: Admin/MPWPB_Staff_Members.php:226
+msgid "Please Type Staff Name....."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:193
+msgid "Staff Password"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:194
+#: Admin/MPWPB_Staff_Members.php:233
+msgid "Please Type Staff Password....."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:198
+msgid "Please Type Staff Email....."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:201
+msgid "Staff First Name"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:202
+msgid "Please Type Staff First Name....."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:205
+msgid "Staff Last Name"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:206
+msgid "Please Type Staff Last Name....."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:210
+msgid "Staff Modify Holiday"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:224
+#: Admin/MPWPB_Staff_Members.php:263
+msgid "Staff Schedule"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:234
+msgid "Save Staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:238
+msgid "Update Staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:240
+msgid "Save New Staff"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:270
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:89
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:501
+#: Admin/settings/Date_Time.php:57
+msgid "Date Type"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:272
+#: Admin/MPWPB_Staff_Members.php:314
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:91
+#: Admin/settings/Date_Time.php:59
+#: Admin/settings/General.php:56
+msgid "Please select ..."
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:273
+#: Admin/MPWPB_Staff_Members.php:315
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:92
+#: Admin/settings/Date_Time.php:60
+msgid "Particular"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:274
+#: Admin/MPWPB_Staff_Members.php:316
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:93
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:492
+#: Admin/settings/Date_Time.php:61
+msgid "Repeated"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:280
+#: Admin/MPWPB_Staff_Members.php:320
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:98
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:492
+#: Admin/settings/Date_Time.php:67
+msgid "Particular Dates"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:295
+#: Admin/MPWPB_Staff_Members.php:335
+#: Admin/settings/Date_Time.php:81
+msgid "Add New Particular date"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:307
+#: Admin/settings/Date_Time.php:92
+msgid "Repeated Start Date"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:315
+#: Admin/MPWPB_Staff_Members.php:353
+#: Admin/settings/Date_Time.php:99
+msgid "Repeated after"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:328
+#: Admin/MPWPB_Staff_Members.php:370
+msgid "Time Schedule Settings"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:335
+#: Admin/MPWPB_Staff_Members.php:383
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:193
+#: Admin/settings/Date_Time.php:148
+msgid "Day"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:336
+#: Admin/MPWPB_Staff_Members.php:385
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:194
+#: Admin/settings/Date_Time.php:149
+#: Admin/settings/Happy_Hours.php:101
+msgid "Start Time"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:338
+#: Admin/MPWPB_Staff_Members.php:387
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:195
+#: Admin/settings/Date_Time.php:150
+#: Admin/settings/Happy_Hours.php:110
+msgid "End Time"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:339
+#: Admin/MPWPB_Staff_Members.php:388
+msgid "Break Time"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:367
+#: Admin/MPWPB_Staff_DashBoard.php:207
+msgid "Off Days & Dates Settings"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:372
+#: Admin/MPWPB_Staff_DashBoard.php:212
+msgid "Off Day"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:385
+#: Admin/MPWPB_Staff_DashBoard.php:225
+msgid "Off Dates"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:400
+#: Admin/MPWPB_Staff_DashBoard.php:247
+#: Admin/MPWPB_Staff_Members.php:449
+#: Admin/settings/Date_Time.php:210
+msgid "Add New Off date"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:481
+#: Admin/MPWPB_Staffs.php:495
+#: Admin/MPWPB_Staff_Members.php:536
+#: Admin/MPWPB_Staff_Members.php:550
+#: Admin/settings/Date_Time.php:295
+#: Admin/settings/Date_Time.php:308
+msgid "No Break"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:517
+#: Admin/MPWPB_Staff_Members.php:572
+#: Admin/settings/Date_Time.php:330
+#: mp_global/class/MPWPB_Custom_Layout.php:200
+msgid "Please select"
+msgstr ""
+
+#: Admin/MPWPB_Staffs.php:519
+#: Admin/MPWPB_Staff_Members.php:574
+#: Admin/settings/Date_Time.php:332
+msgid "Default"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:73
+#: mp_global/class/MPWPB_Booking_Notes.php:219
+msgid "You do not have permission to view this."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:189
+#: Frontend/MPWPB_User_Dashboard.php:48
+#: inc/MPWPB_Dependencies.php:112
+msgid "Are you sure you want to cancel this booking?"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:190
+#: Frontend/MPWPB_User_Dashboard.php:56
+#: inc/MPWPB_Dependencies.php:113
+msgid "Are you sure you want to reschedule this booking?"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:274
+msgid "Users Bookings"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:275
+#: Frontend/MPWPB_User_Dashboard.php:153
+msgid "Upcoming Appointments"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:276
+#: Frontend/MPWPB_User_Dashboard.php:154
+msgid "My Reviews"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:278
+msgid "Manage Holidays"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:346
+#: Frontend/MPWPB_User_Dashboard.php:210
+msgid "Please login to view your bookings"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:349
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:76
+#: Frontend/MPWPB_User_Dashboard.php:213
+msgid "Don't have an account?"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:350
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:77
+#: Frontend/MPWPB_User_Dashboard.php:214
+msgid "Register here"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:363
+#: Frontend/MPWPB_User_Dashboard.php:227
+msgid "You have no bookings yet."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:369
+msgid "Users Booking History"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:376
+#: Admin/MPWPB_Staff_DashBoard.php:1335
+#: Frontend/MPWPB_Recurring_Account_Manager.php:93
+#: Frontend/MPWPB_User_Dashboard.php:240
+#: Frontend/MPWPB_Woocommerce.php:1080
+msgid "Time"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:402
+#: Admin/MPWPB_Staff_DashBoard.php:520
+#: Frontend/MPWPB_User_Dashboard.php:438
+msgid "Reschedule"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:412
+#: Admin/MPWPB_Staff_DashBoard.php:1079
+#: Frontend/MPWPB_User_Dashboard.php:271
+msgid "View Service"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:428
+msgid "No services found."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:444
+#: Frontend/MPWPB_User_Dashboard.php:534
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:101
+msgid "Reschedule Booking"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:450
+#: Frontend/MPWPB_User_Dashboard.php:540
+msgid "Select New Date"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:452
+#: Frontend/MPWPB_User_Dashboard.php:542
+#: inc/MPWPB_Localization.php:190
+msgid "Select Date"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:458
+#: Frontend/MPWPB_User_Dashboard.php:548
+msgid "Select New Time"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:460
+#: Frontend/MPWPB_User_Dashboard.php:550
+#: inc/MPWPB_Localization.php:191
+msgid "Select Time"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:467
+#: Frontend/MPWPB_User_Dashboard.php:557
+msgid "Confirm Reschedule"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:483
+#: Frontend/MPWPB_User_Dashboard.php:291
+msgid "You have no upcoming appointments."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:489
+#: Frontend/MPWPB_User_Dashboard.php:297
+msgid "My Upcoming Appointments"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:539
+#: Frontend/MPWPB_User_Dashboard.php:155
+#: Frontend/MPWPB_User_Dashboard.php:590
+msgid "My Profile"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:544
+#: Admin/MPWPB_Staff_Members.php:246
+#: Frontend/MPWPB_Native_Checkout.php:425
+#: Frontend/MPWPB_Native_Checkout.php:724
+#: Frontend/MPWPB_User_Dashboard.php:604
+msgid "First Name"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:549
+#: Admin/MPWPB_Staff_Members.php:250
+#: Frontend/MPWPB_Native_Checkout.php:429
+#: Frontend/MPWPB_Native_Checkout.php:728
+#: Frontend/MPWPB_User_Dashboard.php:608
+msgid "Last Name"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:556
+#: Admin/MPWPB_Staff_Members.php:237
+#: Frontend/MPWPB_Native_Checkout.php:734
+msgid "Email"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:573
+#: Frontend/MPWPB_User_Dashboard.php:636
+msgid "City"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:580
+msgid "New Password (leave blank to keep current)"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:585
+#: Frontend/MPWPB_User_Dashboard.php:655
+msgid "Confirm New Password"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:591
+#: Frontend/MPWPB_User_Dashboard.php:666
+msgid "Service Preferences"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:593
+msgid "Enter any preferences you have for your service bookings."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:598
+#: Frontend/MPWPB_User_Dashboard.php:678
+msgid "Update Profile"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:745
+#: Frontend/MPWPB_User_Dashboard.php:931
+msgid "Invalid booking ID"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:753
+#: Frontend/MPWPB_User_Dashboard.php:939
+msgid "You do not have permission to cancel this booking"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:756
+msgid "Booking cancelled by staff."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:762
+msgid "Booking cancelled successfully"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:780
+#: Frontend/MPWPB_User_Dashboard.php:1018
+msgid "Missing required fields"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:790
+#: Frontend/MPWPB_User_Dashboard.php:1026
+msgid "You do not have permission to reschedule this booking"
+msgstr ""
+
+#. translators: %s: new booking date/time
+#: Admin/MPWPB_Staff_DashBoard.php:796
+#, php-format
+msgid "Booking rescheduled by staff. New date/time: %s"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:806
+#: Frontend/MPWPB_User_Dashboard.php:1042
+msgid "Booking rescheduled successfully"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:847
+#: Frontend/MPWPB_User_Dashboard.php:1140
+msgid "Profile updated successfully"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1008
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:92
+#: Frontend/MPWPB_Wc_Staff_Account.php:79
+msgid "My Service"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1009
+msgid "View and manage your service offerings and status."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1013
+msgid "New Service"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1020
+#: templates/layout/service_list.php:239
+msgid "Total Services"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1024
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:248
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:772
+#: templates/layout/service_list.php:293
+msgid "Published"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1028
+msgid "Drafts"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1032
+msgid "Service Reach"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1038
+msgid "You haven't been assigned to any services yet."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1045
+#: Admin/settings/Extra_service.php:262
+#: Admin/settings/Service.php:229
+#: Admin/settings/Service.php:328
+msgid "Service Name"
+msgstr ""
+
+#. translators: %d: service post ID
+#: Admin/MPWPB_Staff_DashBoard.php:1065
+#, php-format
+msgid "ID: #%d"
+msgstr ""
+
+#. translators: 1: first row number shown, 2: last row number shown, 3: total matching services
+#: Admin/MPWPB_Staff_DashBoard.php:1090
+#, php-format
+msgid "Showing %1$d to %2$d of %3$d entries"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1128
+msgid "That appointment could not be found."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1157
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:93
+#: Frontend/MPWPB_Wc_Staff_Account.php:80
+msgid "My Appointment"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1158
+msgid "Review and manage your upcoming service schedule."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1189
+#: Admin/MPWPB_Staff_DashBoard.php:1338
+msgid "Service Status"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1203
+msgid "Clear"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1220
+msgid "Internal Notes"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1223
+msgid "Write a note for the admin..."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1227
+msgid "Send"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1241
+msgid "Send Review Request"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1244
+msgid "Subject"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1248
+msgid "Message"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1325
+msgid "No appointments found for the selected range."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1378
+msgid "Not Set"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1383
+#: Admin/settings/Category.php:142
+#: Admin/settings/Extra_service.php:301
+#: Admin/settings/Faq.php:131
+#: Admin/settings/Service.php:272
+#: Admin/settings/Service.php:371
+msgid "Save"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1391
+msgid "Internal Notes (private, admin only)."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1399
+msgid "Send Review Request."
+msgstr ""
+
+#. translators: 1: number of rows shown on this page, 2: total matching appointments
+#: Admin/MPWPB_Staff_DashBoard.php:1415
+#, php-format
+msgid "Showing %1$d of %2$d appointments"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1438
+msgid "Today's Visits"
+msgstr ""
+
+#. translators: %d: number of appointments today
+#: Admin/MPWPB_Staff_DashBoard.php:1443
+#, php-format
+msgid "%d Appointment"
+msgid_plural "%d Appointments"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1453
+msgid "Pending Processing"
+msgstr ""
+
+#. translators: %d: number of pending/processing appointments
+#: Admin/MPWPB_Staff_DashBoard.php:1458
+#, php-format
+msgid "%d Unit"
+msgid_plural "%d Units"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1468
+msgid "Quick Action"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1469
+msgid "New Booking"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1507
+msgid "Back to My Appointment"
+msgstr ""
+
+#. translators: %d: booking ID
+#: Admin/MPWPB_Staff_DashBoard.php:1512
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:176
+#, php-format
+msgid "Appointment #%d"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1531
+#: Frontend/MPWPB_Native_Checkout.php:420
+#: Frontend/MPWPB_Native_Checkout.php:617
+msgid "Customer Information"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1536
+#: Frontend/MPWPB_Native_Checkout.php:622
+msgid "Full Name"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1540
+#: Frontend/MPWPB_Native_Checkout.php:435
+#: Frontend/MPWPB_Native_Checkout.php:626
+#: Frontend/MPWPB_User_Dashboard.php:614
+msgid "Email Address"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1546
+#: Frontend/MPWPB_Native_Checkout.php:439
+#: Frontend/MPWPB_Native_Checkout.php:633
+#: Frontend/MPWPB_User_Dashboard.php:618
+msgid "Phone Number"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1587
+msgid "Your schedule can only be changed by an administrator. Please contact them if you'd like to update your availability."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1601
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:95
+#: Frontend/MPWPB_Wc_Staff_Account.php:82
+msgid "My Schedule"
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1602
+msgid "Set your weekly working hours, break times, and the days/dates you are unavailable. Saving here updates the same availability used to calculate your bookable time slots."
+msgstr ""
+
+#: Admin/MPWPB_Staff_DashBoard.php:1605
+msgid "Save Schedule"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:64
+msgid "Add Image"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:81
+msgid "Staff Management"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:82
+msgid "Configure staff details and recurring scheduling parameters."
+msgstr ""
+
+#. translators: 1: number of staff shown, 2: total number of staff
+#: Admin/MPWPB_Staff_Members.php:160
+#, php-format
+msgid "Showing 1 to %1$d of %2$d staff members"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:167
+#: templates/layout/service_list.php:339
+msgid "Previous page"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:169
+#: templates/layout/service_list.php:341
+msgid "Next page"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:200
+msgid "Update staff profile and account credentials."
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:223
+msgid "Username"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:230
+msgid "Password"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:240
+msgid "Please enter email"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:247
+#: Admin/MPWPB_Staff_Members.php:251
+msgid "Type name"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:256
+msgid "Modify Holiday Permissions"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:275
+#: Admin/MPWPB_Staff_Members.php:276
+msgid "Save Profile"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:304
+msgid "Schedule Type"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:307
+msgid "Repeated Weekly"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:310
+msgid "One-time Schedule"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:346
+msgid "Effective From"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:373
+msgid "Copy Monday's hours to every other day"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:374
+msgid "Copy Monday to All"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:376
+msgid "Set under Settings → 24 Hour Time Format"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:376
+msgid "24H Format"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:376
+msgid "12H Format"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:416
+msgid "Off Days & Exception Dates"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:422
+msgid "Weekly Off Days"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:434
+msgid "Exception Dates"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:481
+#: inc/MPWPB_Dependencies.php:137
+#: templates/layout/coupon_list.php:31
+#: templates/layout/coupon_list.php:37
+msgid "OFF"
+msgstr ""
+
+#: Admin/MPWPB_Staff_Members.php:481
+#: inc/MPWPB_Dependencies.php:136
+msgid "ACTIVE"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:106
+msgid "System Status"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:107
+msgid "Server, PHP, database and WordPress environment for your booking system."
+msgstr ""
+
+#: Admin/MPWPB_Status.php:110
+#: Admin/MPWPB_Status.php:133
+msgid "PHP"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:111
+#: Admin/MPWPB_Status.php:155
+msgid "WordPress"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:121
+msgid "Server"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:123
+msgid "Web Server"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:124
+msgid "Operating System"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:125
+msgid "Hostname"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:126
+msgid "Server IP"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:127
+msgid "HTTPS"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:128
+msgid "PHP Interface"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:135
+msgid "PHP Version"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:135
+#: Admin/MPWPB_Status.php:157
+msgid "Good"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:135
+#: Admin/MPWPB_Status.php:157
+msgid "Update advised"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:135
+msgid "Outdated"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:136
+msgid "Memory Limit"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:136
+#: Admin/MPWPB_Status.php:137
+#: Admin/MPWPB_Status.php:138
+msgid "OK"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:136
+#: Admin/MPWPB_Status.php:137
+#: Admin/MPWPB_Status.php:138
+msgid "Low"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:137
+msgid "Max Execution Time"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:138
+msgid "Upload Max Filesize"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:139
+msgid "Post Max Size"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:140
+msgid "Max Input Vars"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:141
+msgid "Display Errors"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:141
+#: Admin/MPWPB_Status.php:161
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:536
+msgid "On"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:146
+msgid "Database"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:148
+msgid "Server Version"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:149
+msgid "Charset"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:150
+msgid "Table Prefix"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:157
+#: Admin/MPWPB_Status.php:173
+#: Admin/MPWPB_Status.php:186
+msgid "Version"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:158
+msgid "WP Memory Limit"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:159
+msgid "Max Upload Size"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:160
+msgid "Multisite"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:161
+msgid "Debug Mode"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:162
+msgid "Language"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:163
+msgid "Timezone"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:164
+msgid "Permalinks"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:164
+msgid "Plain"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:171
+msgid "Installed"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:174
+msgid "Currency"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:175
+msgid "Email From Name"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:175
+#: Admin/MPWPB_Status.php:176
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:421
+msgid "Not set"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:176
+msgid "Email From Address"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:182
+msgid "Theme &amp; Plugins"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:184
+msgid "Active Theme"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:185
+msgid "Active Plugins"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:193
+msgid "PHP Extensions"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:212
+msgid "Add-ons &amp; Libraries"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:224
+msgid "Dummy Data Import"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:227
+msgid "Dummy data has already been imported. You can re-import to restore the default demo services."
+msgstr ""
+
+#: Admin/MPWPB_Status.php:229
+msgid "Import dummy services to quickly see how Service Booking Manager works. This creates sample service posts with categories and settings."
+msgstr ""
+
+#: Admin/MPWPB_Status.php:233
+msgid "Re-Import Dummy Data"
+msgstr ""
+
+#: Admin/MPWPB_Status.php:233
+msgid "Import Dummy Data"
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:23
+#: Admin/MPWPB_Taxonomy.php:24
+msgid "Parent "
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:25
+msgid " Name"
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:26
+msgid "Add New "
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:30
+msgid "Separate "
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:30
+msgid " with commas"
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:31
+msgid "Add or remove "
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:32
+msgid "Choose from the most used"
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:33
+msgid "Popular "
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:35
+msgid "Not Found"
+msgstr ""
+
+#: Admin/MPWPB_Taxonomy.php:36
+msgid "No "
+msgstr ""
+
+#: Admin/MPWPB_Wc_Checkout_Fields.php:86
+#: Admin/MPWPB_Wc_Checkout_Settings.php:68
+msgid "You do not have sufficient permissions to access this page."
+msgstr ""
+
+#: Admin/MPWPB_Wc_Checkout_Settings.php:46
+msgid "Hide Order Additional Information Section"
+msgstr ""
+
+#: Admin/MPWPB_Wc_Checkout_Settings.php:50
+msgid "Hide Order Review Section"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:74
+#: templates/layout/service_list.php:241
+msgid "All services"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:75
+msgid "Uncategorized"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:76
+msgid "New category"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:77
+msgid "No category"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:78
+msgid "Add service"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:79
+msgid "Edit service"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:80
+msgid "Add category"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:81
+msgid "Add subcategory"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:82
+msgid "Delete category?"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:83
+msgid "Delete service?"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:84
+msgid "Search services"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:85
+msgid "No services here yet"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:86
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:71
+msgid "Try a different search."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:87
+msgid "Add a service to this view — you can assign a category later."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:88
+msgid "No categories yet. Create one to start organizing."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:89
+msgid "Counts include services in subcategories. Deleting a category moves its services to Uncategorized — nothing is lost."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Categories_Services_Modern.php:101
+msgid "Organize services into categories, or leave them uncategorized."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:85
+msgid "General Configuration"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:104
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:112
+msgid "Bookable date"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:109
+msgid "Add New Particular Date"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:122
+msgid "Max Advanced Booking (Days)"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:135
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:505
+#: Admin/settings/Date_Time.php:112
+msgid "Time Slot Length"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:137
+#: Admin/settings/Date_Time.php:121
+msgid "Select time slot Length"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:141
+#: Admin/settings/Date_Time.php:125
+msgid "Custom…"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:146
+msgid "Ex. 45"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:147
+msgid "Length in minutes."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:152
+#: Admin/settings/Date_Time.php:136
+msgid "Capacity per Session"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:161
+msgid "Weekly Off-days"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:164
+msgid "Select the days the operation is closed."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:184
+msgid "Weekly Schedule"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:185
+msgid "Configure standard operating hours for each day."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:187
+#, php-format
+msgid "%1$d / %2$d Days Open"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:196
+msgid "Break (Start)"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:197
+msgid "Break (End)"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:219
+msgid "Special Dates & Holidays"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:220
+msgid "Add specific dates where the standard schedule does not apply."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:222
+msgid "Add Special Date"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:231
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:239
+msgid "Operation: Closed"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Date_Time_Modern.php:236
+msgid "No special dates added yet."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:65
+#: Admin/settings/Extra_service.php:247
+#: Admin/settings/Extra_service.php:254
+msgid "Add Extra Service"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:66
+msgid "Edit Extra Service"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:67
+msgid "Delete extra service?"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:68
+msgid "Search extra services"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:69
+msgid "No extra services yet"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Extra_Service_Modern.php:70
+msgid "Add an optional paid add-on customers can choose during booking."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:69
+msgid "Editor Style"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:104
+#: Frontend/MPWPB_Static_Template.php:436
+msgid "Customer Reviews"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:104
+msgid "Rating, scale and review count shown for this service."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:105
+msgid "Service Feature Details"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:105
+msgid "Highlight key features of this service."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:106
+msgid "Overview and details content shown on the service page."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:111
+msgid "Pricing"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:114
+msgid "Optional paid add-ons customers can choose during booking."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:119
+msgid "Availability"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:121
+msgid "Available dates, weekly schedule, off days and time slots."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:126
+msgid "Advanced"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:128
+msgid "Frequently asked questions shown on the service page."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:129
+#: Admin/settings/Tax_Settings.php:83
+msgid "Tax Settings"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:129
+msgid "Charge tax on this service using your WooCommerce tax settings."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:130
+msgid "Discount the price when the booked appointment time falls in a set window."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:137
+msgid "Assign staff members who can be booked for this service."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:138
+msgid "Let customers book this service on a recurring schedule."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:237
+#, php-format
+msgid "Back to %s"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:252
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:823
+msgid "Local autosave ready"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:257
+msgid "Preview"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:267
+msgid "Classic editor"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:287
+msgid "No payment method is currently configured."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:289
+msgid "Please configure a payment method to accept bookings."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:342
+#: Frontend/MPWPB_Inline_WC_Checkout.php:138
+#: templates/registration/next_date_time.php:27
+#: templates/registration/next_date_time.php:32
+msgid "Back"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:343
+#, php-format
+msgid "Step %1$d of %2$d"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:344
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:828
+msgid "Next Step"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:350
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:768
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:820
+msgid "Saved"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:369
+msgid "Featured Image"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:376
+msgid "Change image"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:376
+msgid "Set image"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:377
+#: Frontend/MPWPB_Coupon_Frontend.php:237
+#: Frontend/MPWPB_Coupon_Frontend.php:334
+#: Frontend/MPWPB_Native_Checkout.php:339
+msgid "Remove"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:406
+msgid "Gallery Images"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:407
+msgid "Additional photos."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:438
+msgid "Active Method"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:442
+msgid "Active Gateway"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:447
+msgid "Payment Settings"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:452
+msgid "Configure payment method"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:468
+msgid "Shortcode &amp; Template"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:477
+msgid "General Info Summary"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:480
+#: Admin/settings/General.php:40
+#: Admin/settings/General.php:41
+msgid "Service Title"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:498
+msgid "Availability Summary"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:509
+msgid "Capacity / Session"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:524
+msgid "Pricing Summary"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:531
+#: Frontend/MPWPB_Woocommerce.php:1090
+#: inc/MPWPB_Localization.php:192
+msgid "Extra Services"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:535
+msgid "Extra Service Enabled"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:632
+msgid "Basic Information"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:633
+msgid "The core details of your service."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:637
+msgid "Title"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:645
+msgid "Service Sub Title"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:652
+#: Admin/settings/Service_Details.php:74
+#: Admin/settings/Service_Details.php:75
+#: Frontend/MPWPB_Static_Template.php:192
+msgid "Service Overview"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:668
+msgid "Classic"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:669
+msgid "Modern"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:672
+msgid "Choose how the service editor looks for your account. This only affects you."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:736
+msgid "You are not allowed to edit this service."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:741
+msgid "The service form expired. Please refresh the page and try again."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:763
+msgid "The service could not be saved."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:822
+msgid "The service could not be saved. Please try again."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:824
+msgid "Saving locally…"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:825
+msgid "Draft saved locally"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:826
+msgid "Local draft restored"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:827
+msgid "Local autosave unavailable"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:830
+msgid "Time Window"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:831
+msgid "Choose when the special price applies."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:832
+msgid "Discount Offer"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:833
+msgid "Set the discount customers receive."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:834
+msgid "Active pricing rule"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:835
+msgid "discount"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:836
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:847
+msgid "Automatic"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:838
+msgid "Repeat Pattern"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:839
+msgid "Choose the recurrence options customers can use."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:840
+msgid "Limits & Incentive"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:841
+msgid "Control the maximum series length and optional discount."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:842
+msgid "Booking series"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:843
+msgid "occurrences maximum"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:844
+msgid "recurring discount"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:845
+msgid "Select a repeat pattern"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:846
+msgid "Applied tax rule"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:849
+msgid "Choose the team members customers can book."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:850
+msgid "staff selected"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:851
+msgid "No staff members available."
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:852
+msgid "Select featured image"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:853
+msgid "Use image"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:854
+msgid "Featured image set"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:855
+msgid "Featured image removed"
+msgstr ""
+
+#: Admin/settings-modern/MPWPB_Settings_Modern.php:891
+msgid "Days Open"
+msgstr ""
+
+#: Admin/settings/Category.php:62
+#: Admin/settings/Category.php:89
+#: Admin/settings/Category.php:165
+#: Admin/settings/Category.php:184
+#: Admin/settings/Category.php:418
+#: Admin/settings/Category.php:463
+#: Admin/settings/Category.php:507
+#: Admin/settings/Extra_service.php:51
+#: Admin/settings/Extra_service.php:98
+#: Admin/settings/Extra_service.php:142
+#: Admin/settings/Extra_service.php:191
+#: Admin/settings/Faq.php:50
+#: Admin/settings/Faq.php:190
+#: Admin/settings/Pricing.php:26
+#: Admin/settings/Service.php:57
+#: Admin/settings/Service.php:112
+#: Admin/settings/Service.php:131
+#: Admin/settings/Service.php:169
+#: Admin/settings/Service.php:446
+#: Admin/settings/Service.php:522
+msgid "Data Updated Successfully"
+msgstr ""
+
+#: Admin/settings/Category.php:107
+msgid "Add Category"
+msgstr ""
+
+#: Admin/settings/Category.php:114
+msgid "Add Category Service"
+msgstr ""
+
+#: Admin/settings/Category.php:123
+msgid "Category Name *"
+msgstr ""
+
+#: Admin/settings/Category.php:127
+msgid "Use As Sub Category"
+msgstr ""
+
+#: Admin/settings/Category.php:130
+msgid "Select Parent Category"
+msgstr ""
+
+#: Admin/settings/Category.php:137
+msgid "Category Image/Icon"
+msgstr ""
+
+#: Admin/settings/Category.php:148
+#: Admin/settings/Extra_service.php:307
+#: Admin/settings/Faq.php:137
+#: Admin/settings/Service.php:278
+#: Admin/settings/Service.php:377
+msgid "Update and Close"
+msgstr ""
+
+#: Admin/settings/Category.php:197
+#: Admin/settings/Service.php:215
+#: Admin/settings/Service.php:314
+#: inc/MPWPB_Localization.php:188
+msgid "Select Category"
+msgstr ""
+
+#: Admin/settings/Category.php:208
+#: Admin/settings/Category.php:225
+#: Admin/settings/Service.php:222
+#: Admin/settings/Service.php:321
+msgid "Select Sub Category"
+msgstr ""
+
+#: Admin/settings/Category.php:539
+#: Admin/settings/Category.php:579
+#: Admin/settings/Extra_service.php:403
+#: Admin/settings/Faq.php:253
+#: Admin/settings/Service.php:553
+msgid "Data Deleted Successfully"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:42
+msgid "Date & Time Settings"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:46
+msgid "General date time and Schedule settings"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:53
+msgid "Date time settings"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:105
+msgid "Maximum advanced day booking"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:130
+msgid "Ex. 45 (minutes)"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:143
+msgid "Shedule settings"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:151
+msgid "Break Time (Start - End)"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:171
+#: Admin/settings/Date_Time.php:172
+msgid "Offdays and date settings"
+msgstr ""
+
+#: Admin/settings/Date_Time.php:195
+msgid "Off date"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:223
+msgid "Extra Service Configuration"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:224
+msgid "Here you can configure Extra Service."
+msgstr ""
+
+#: Admin/settings/Extra_service.php:227
+#: Admin/settings/Extra_service.php:228
+msgid "Extra Service Settings"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:233
+msgid "Enable Extra Service"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:234
+msgid "Enable Extra Service."
+msgstr ""
+
+#: Admin/settings/Extra_service.php:270
+msgid "Quantity"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:278
+#: Admin/settings/Service.php:249
+#: Admin/settings/Service.php:348
+msgid "Image/Icon"
+msgstr ""
+
+#: Admin/settings/Extra_service.php:292
+#: Admin/settings/Service.php:187
+#: Admin/settings/Service.php:263
+#: Admin/settings/Service.php:362
+#: mp_global/class/MPWPB_Select_Icon_image.php:108
+#: mp_global/class/MPWPB_Select_Icon_image.php:134
+#: mp_global/class/MPWPB_Select_Icon_image.php:160
+msgid "Image"
+msgstr ""
+
+#: Admin/settings/Faq.php:75
+#: Admin/settings/Faq.php:79
+#: Admin/settings/Faq.php:80
+msgid "FAQ Settings"
+msgstr ""
+
+#: Admin/settings/Faq.php:76
+msgid "FAQ Settings will be here."
+msgstr ""
+
+#: Admin/settings/Faq.php:85
+#: Admin/settings/Faq.php:86
+msgid "Enable FAQ Section"
+msgstr ""
+
+#: Admin/settings/Faq.php:97
+msgid "Add FAQ"
+msgstr ""
+
+#: Admin/settings/Faq.php:104
+msgid "Add F.A.Q."
+msgstr ""
+
+#: Admin/settings/Faq.php:109
+msgid "Add Title"
+msgstr ""
+
+#: Admin/settings/Faq.php:115
+msgid "Add Content"
+msgstr ""
+
+#: Admin/settings/Faq.php:219
+msgid "Data Added Successfully"
+msgstr ""
+
+#: Admin/settings/Gallery.php:22
+msgid "On/Off Slider"
+msgstr ""
+
+#: Admin/settings/Gallery.php:31
+msgid "Gallery Images "
+msgstr ""
+
+#: Admin/settings/General.php:22
+#: Admin/settings/General.php:26
+msgid "General Information Settings"
+msgstr ""
+
+#: Admin/settings/General.php:32
+msgid "Add To Cart Form Shortcode"
+msgstr ""
+
+#: Admin/settings/General.php:46
+msgid "Service sub title"
+msgstr ""
+
+#: Admin/settings/General.php:53
+msgid "Service template"
+msgstr ""
+
+#: Admin/settings/General.php:57
+msgid "Regular"
+msgstr ""
+
+#: Admin/settings/General.php:58
+msgid "Static"
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:60
+msgid "Give a discount when the customer books an appointment time inside a set window."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:75
+msgid "Enable Happy Hours"
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:76
+msgid "Off by default. The discount is based on the appointment time the customer picks, not the time they check out."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:102
+msgid "Appointment times at or after this time qualify."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:111
+msgid "Appointment times before this time qualify."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:120
+msgid "Percentage off, or a fixed amount off."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:124
+msgid "Percentage (%)"
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:131
+msgid "Discount Value"
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:132
+msgid "e.g. 20 for 20% off, or 20 for $20 off with Fixed Amount."
+msgstr ""
+
+#: Admin/settings/Happy_Hours.php:135
+msgid "e.g. 20"
+msgstr ""
+
+#: Admin/settings/Pricing.php:39
+msgid "Services and Price Settings"
+msgstr ""
+
+#: Admin/settings/Pricing.php:40
+msgid "Manage and customize your offerings with ease! Create new services, organize them into categories, and set competitive prices to cater to your customers' needs effectively."
+msgstr ""
+
+#: Admin/settings/Pricing.php:44
+msgid "Category and Services"
+msgstr ""
+
+#: Admin/settings/Pricing.php:45
+msgid "Create and organize service categories, adding services under each to keep everything structured and accessible."
+msgstr ""
+
+#: Admin/settings/Pricing.php:51
+msgid "Categories"
+msgstr ""
+
+#: Admin/settings/Pricing.php:52
+msgid "☰ Show All service"
+msgstr ""
+
+#: Admin/settings/Pricing.php:59
+msgid "Add New Service"
+msgstr ""
+
+#: Admin/settings/Pricing.php:76
+msgid "If you have trouble with old data, click to "
+msgstr ""
+
+#: Admin/settings/Pricing.php:76
+msgid "Import Old Services"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:30
+#: Admin/settings/Recurring_Booking.php:34
+msgid "Recurring Booking Settings"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:31
+#: Admin/settings/Recurring_Booking.php:35
+msgid "Configure recurring booking options for this service"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:39
+msgid "Enable Recurring Bookings"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:46
+msgid "Recurring Types"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:51
+#: templates/registration/date_time_select.php:153
+msgid "Daily"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:55
+#: Frontend/MPWPB_Recurring_Booking.php:218
+#: Frontend/MPWPB_Recurring_Booking.php:279
+#: templates/registration/date_time_select.php:156
+msgid "Weekly"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:59
+#: Frontend/MPWPB_Recurring_Booking.php:221
+#: Frontend/MPWPB_Recurring_Booking.php:282
+#: templates/registration/date_time_select.php:159
+msgid "Bi-Weekly"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:63
+#: Frontend/MPWPB_Recurring_Booking.php:224
+#: Frontend/MPWPB_Recurring_Booking.php:285
+#: templates/registration/date_time_select.php:162
+msgid "Monthly"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:70
+msgid "Maximum Recurring Count"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:77
+msgid "Recurring Booking Discount (%)"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:106
+#: Admin/settings/Recurring_Booking.php:208
+#: Frontend/MPWPB_Recurring_Booking.php:91
+msgid "Recurring dates generated successfully"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:132
+#: Admin/settings/Waiting_List.php:165
+#: Frontend/MPWPB_Recurring_Booking.php:74
+msgid "Invalid data provided"
+msgstr ""
+
+#: Admin/settings/Recurring_Booking.php:191
+msgid "Already Booked"
+msgstr ""
+
+#: Admin/settings/Service.php:149
+msgid "Data Loaded Successfully"
+msgstr ""
+
+#: Admin/settings/Service.php:188
+msgid "Name"
+msgstr ""
+
+#: Admin/settings/Service.php:212
+#: Admin/settings/Service.php:311
+msgid "Use Category"
+msgstr ""
+
+#: Admin/settings/Service.php:237
+#: Admin/settings/Service.php:336
+msgid "Service Unit"
+msgstr ""
+
+#: Admin/settings/Service.php:508
+msgid "This parent category contains subcategories. Please add this service under one of the subcategories."
+msgstr ""
+
+#: Admin/settings/Service_Details.php:32
+msgid "Service Details Settings"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:33
+msgid "Service Details will be here."
+msgstr ""
+
+#: Admin/settings/Service_Details.php:37
+#: Admin/settings/Service_Details.php:38
+#: Admin/settings/Service_Details.php:42
+msgid "Service Features"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:63
+msgid "Add New Feature"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:79
+msgid "Enable Service Overview"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:95
+msgid "Enable Service Details"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:106
+msgid "Service Review"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:107
+msgid "Service Review Settings"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:111
+msgid "Service Review Rating"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:118
+msgid "Service Review Scale"
+msgstr ""
+
+#: Admin/settings/Service_Details.php:126
+msgid "Service Review Text"
+msgstr ""
+
+#: Admin/settings/Service_Settings.php:41
+msgid "Service Settings will be here."
+msgstr ""
+
+#: Admin/settings/Service_Settings.php:46
+msgid "Enable Multiple Category Check"
+msgstr ""
+
+#: Admin/settings/Service_Settings.php:56
+msgid "Enable Multiple Service Select"
+msgstr ""
+
+#: Admin/settings/Staff_Member.php:86
+msgid "Staff Member Settings"
+msgstr ""
+
+#: Admin/settings/Staff_Member.php:87
+msgid "Staff Member will be here."
+msgstr ""
+
+#: Admin/settings/Staff_Member.php:93
+#: Admin/settings/Staff_Member.php:94
+msgid "Enable Staff Member Add"
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:79
+#: mp_global/class/MPWPB_Partial_Payment.php:173
+#: mp_global/class/MPWPB_Partial_Payment.php:391
+#: mp_global/class/MPWPB_Tax_Helper.php:55
+msgid "Standard"
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:84
+msgid "Charge tax on this service -- works with or without WooCommerce."
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:90
+msgid "Enable Tax"
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:91
+msgid "Off by default. Pick a tax class and rate below -- if WooCommerce is active it is synced there automatically, no need to open WooCommerce's own tax settings."
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:105
+msgid "Tax Class"
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:106
+msgid "A rate is shared by every service using the same class -- pick a different class if this service needs a different rate."
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:118
+msgid "Tax Rate (%)"
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:119
+msgid "The percentage charged for the tax class selected above."
+msgstr ""
+
+#: Admin/settings/Tax_Settings.php:122
+msgid "e.g. 8.5"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:33
+#: Admin/settings/Waiting_List.php:37
+msgid "Waiting List Settings"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:34
+#: Admin/settings/Waiting_List.php:38
+msgid "Configure waiting list options for fully booked time slots"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:43
+msgid "Enable Waiting List"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:44
+msgid "Allow customers to join waiting list for fully booked slots"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:57
+msgid "Maximum Waiting List Size"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:58
+msgid "Maximum number of people allowed on waiting list per time slot"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:66
+msgid "Notification Email Subject"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:67
+msgid "Subject for notification email when slot becomes available"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:75
+msgid "Notification Email Body"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:77
+msgid "Body for notification email when slot becomes available"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:79
+msgid "Available placeholders: {customer_name}, {service_name}, {date}, {time}, {site_name}"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:99
+msgid "Please fill all required fields"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:106
+msgid "Waiting list is not enabled for this service"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:115
+msgid "This time slot is not eligible for the waiting list."
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:128
+msgid "Waiting list is full for this time slot"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:135
+msgid "You are already on the waiting list for this time slot"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:153
+msgid "You have been added to the waiting list. We will notify you if a slot becomes available."
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:257
+#, php-format
+msgid "You have been added to the waiting list for %s"
+msgstr ""
+
+#: Admin/settings/Waiting_List.php:260
+#, php-format
+msgid ""
+"Hello %s,\n"
+"\n"
+"You have been added to the waiting list for %s on %s at %s.\n"
+"\n"
+"We will notify you if a slot becomes available.\n"
+"\n"
+"Regards,\n"
+"%s"
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:55
+#: Frontend/MPWPB_Coupon_Frontend.php:196
+msgid "Please enter a coupon code."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:77
+#: Frontend/MPWPB_Coupon_Frontend.php:86
+msgid "Coupon removed."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:94
+#: Frontend/MPWPB_Inline_WC_Checkout.php:108
+#: Frontend/MPWPB_Native_Checkout.php:395
+#: Frontend/MPWPB_Native_Checkout.php:650
+#: mp_global/class/MPWPB_Partial_Payment.php:246
+msgid "Your booking cart is empty."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:106
+#: Frontend/MPWPB_Coupon_Frontend.php:133
+msgid "Coupon applied."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:113
+#: Frontend/MPWPB_Coupon_Frontend.php:182
+#: mp_global/class/MPWPB_Partial_Payment.php:226
+#: mp_global/class/MPWPB_Partial_Payment.php:242
+msgid "Cart unavailable."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:117
+#: Frontend/MPWPB_Coupon_Frontend.php:186
+#: mp_global/class/MPWPB_Partial_Payment.php:230
+msgid "Your cart has no bookable service."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:232
+#: Frontend/MPWPB_Woocommerce.php:475
+msgid "Booking coupon"
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:234
+#: Frontend/MPWPB_Native_Checkout.php:344
+msgid "Apply"
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:235
+msgid "Applying…"
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:236
+msgid "Applied"
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:238
+msgid "Unable to update the coupon. Please try again."
+msgstr ""
+
+#: Frontend/MPWPB_Coupon_Frontend.php:339
+msgid "Apply Coupon"
+msgstr ""
+
+#. translators: %s: reason the coupon is no longer valid
+#. translators: %s: coupon validation failure reason
+#: Frontend/MPWPB_Coupon_Frontend.php:363
+#: Frontend/MPWPB_Woocommerce.php:523
+#: Frontend/MPWPB_Woocommerce.php:554
+#, php-format
+msgid "Your coupon is no longer valid: %s"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:53
+msgid "My Dashboard"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:67
+msgid "This page is only available when Custom Payment is enabled."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:73
+msgid "Please login to view your account"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:88
+msgid "Dashboard"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:98
+msgid "Account Details"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:100
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:217
+#: Frontend/MPWPB_User_Dashboard.php:158
+#: Frontend/MPWPB_User_Dashboard.php:727
+msgid "Privacy & Data"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:111
+msgid "Logout"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:166
+#: Frontend/MPWPB_User_Dashboard.php:115
+msgid "Account overview"
+msgstr ""
+
+#. translators: %s: customer display name
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:171
+#, php-format
+msgid "Hello, %s!"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:176
+msgid "View your recent custom payment orders, manage your account details, and control your privacy preferences from one place."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:180
+msgid "Log out"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:187
+msgid "Latest activity"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:188
+msgid "Recent Orders"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:192
+msgid "View all orders"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:205
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:268
+msgid "No orders yet"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:206
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:269
+msgid "Your custom payment orders will appear here after checkout."
+msgstr ""
+
+#. translators: %s: "Privacy & Data" tab link
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:216
+#, php-format
+msgid "Want to manage your privacy consent or request your data be deleted? Visit the %s tab."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:237
+msgid "That order could not be found."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:245
+msgid "Order history"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:246
+msgid "My Custom Payment Orders"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:247
+msgid "Review your payment history and manage the bookings connected to each order."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:292
+msgid "Back to Orders"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:298
+msgid "Order details"
+msgstr ""
+
+#. translators: %d: order ID
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:303
+#, php-format
+msgid "Order #%d"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:308
+msgid "Review your payment information, appointment schedule, and booking details."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:316
+msgid "Order Date"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:328
+msgid "Order Total"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:359
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:125
+msgid "Manage Your Booking"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:360
+msgid "Reorder this service or update your appointment when available."
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:366
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:393
+#: Frontend/MPWPB_User_Dashboard.php:267
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:47
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:129
+msgid "Reorder"
+msgstr ""
+
+#: Frontend/MPWPB_Custom_Payment_My_Account.php:446
+#: templates/registration/category_selection.php:125
+#: templates/registration/category_selection.php:126
+#: templates/registration/extra_services.php:49
+msgid "View Details"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:88
+#: templates/registration/waiting_list_modal.php:13
+#: templates/registration/waiting_list_modal.php:52
+msgid "Join Waiting List"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:92
+msgid "Booked"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:124
+msgid "No booking dates are currently available."
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:166
+msgid "Today"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:168
+msgid "Tomorrow"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:182
+msgid "Closed"
+msgstr ""
+
+#: Frontend/MPWPB_Details_Layout.php:198
+msgid "Passed"
+msgstr ""
+
+#: Frontend/MPWPB_Display_Fixer.php:79
+#: Frontend/MPWPB_File_Display_Helper.php:92
+msgid "Uploaded Files"
+msgstr ""
+
+#: Frontend/MPWPB_Display_Fixer.php:104
+#: Frontend/MPWPB_Display_Fixer.php:106
+#: Frontend/MPWPB_File_Display_Helper.php:132
+#: Frontend/MPWPB_File_Display_Helper.php:134
+#: Frontend/MPWPB_Wc_Checkout_Fields_Helper.php:924
+#: Frontend/MPWPB_Wc_Checkout_Fields_Helper.php:929
+msgid "File:"
+msgstr ""
+
+#: Frontend/MPWPB_Display_Fixer.php:110
+#: Frontend/MPWPB_File_Display_Helper.php:138
+msgid "Download"
+msgstr ""
+
+#: Frontend/MPWPB_File_Display_Helper.php:141
+msgid "File uploaded but format not recognized"
+msgstr ""
+
+#: Frontend/MPWPB_File_Display_Helper.php:142
+msgid "Download File"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:63
+#: Frontend/MPWPB_Woocommerce.php:1240
+msgid "Security check failed. Please refresh the page and try again."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:128
+msgid "Billing & Customer Information"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:129
+msgid "Enter the details required to confirm your booking."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:139
+msgid "Continue to Payment"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:144
+msgid "Payment & Booking Summary"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:145
+msgid "Review your booking and choose a payment method."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:157
+msgid "Back to Billing"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:185
+msgid "The order confirmation could not be verified."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:188
+msgid "You are not allowed to view this order."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:194
+msgid "Thank you. Your booking has been received."
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:195
+msgid "Order status:"
+msgstr ""
+
+#: Frontend/MPWPB_Inline_WC_Checkout.php:197
+msgid "Customer email:"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:65
+#: Frontend/MPWPB_Woocommerce.php:97
+msgid "No booking information found."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:143
+msgid "Country"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:151
+msgid "State"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:152
+msgid "e.g. CA"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:156
+msgid "Postcode / ZIP"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:157
+msgid "12345"
+msgstr ""
+
+#. translators: %s: formatted time, e.g. "10:30 AM"
+#: Frontend/MPWPB_Native_Checkout.php:193
+#, php-format
+msgid "l, M j \\@ %s"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:231
+msgid "Appointment Slots"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:231
+msgid "Appointment Slot"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:246
+msgid "Change"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:262
+#: Frontend/MPWPB_Native_Checkout.php:764
+#: inc/MPWPB_Localization.php:193
+msgid "Booking Summary"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:282
+msgid "Extra Service Addons"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:313
+msgid "Rate per visit"
+msgstr ""
+
+#. translators: %d: number of recurring occurrences
+#: Frontend/MPWPB_Native_Checkout.php:320
+#, php-format
+msgid "%d visit"
+msgid_plural "%d visits"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Frontend/MPWPB_Native_Checkout.php:328
+#: Frontend/MPWPB_Recurring_Booking.php:295
+msgid "Recurring Discount"
+msgstr ""
+
+#. translators: %s: applied coupon code
+#: Frontend/MPWPB_Native_Checkout.php:356
+#, php-format
+msgid "Coupon Discount (%s)"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:357
+msgid "Coupon Discount"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:365
+msgid "Estimated Tax"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:379
+msgid "Due Now"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:383
+msgid "Due Later"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:402
+#: Frontend/MPWPB_Native_Checkout.php:657
+msgid "No payment method is currently configured. Please configure a payment method to accept bookings."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:426
+msgid "Enter first name"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:430
+msgid "Enter last name"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:445
+#: Frontend/MPWPB_Native_Checkout.php:744
+msgid "123 Main St, City"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:491
+#: Frontend/MPWPB_Native_Checkout.php:770
+msgid "Confirm Booking"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:577
+#: Frontend/MPWPB_Woocommerce.php:88
+msgid "Thank you, your booking is confirmed!"
+msgstr ""
+
+#. translators: %s: order reference number
+#: Frontend/MPWPB_Native_Checkout.php:583
+#: Frontend/MPWPB_Native_Checkout.php:1018
+#: Frontend/MPWPB_Woocommerce.php:92
+#, php-format
+msgid "Order reference: #%s"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:713
+#: Frontend/MPWPB_Native_Checkout.php:797
+msgid "Please fill in all required fields."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:725
+msgid "John"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:729
+msgid "Doe"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:766
+msgid "Total Amount"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:769
+msgid "By confirming your booking, you agree to our Terms of Service and Privacy Policy."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:771
+msgid "Secure SSL Encrypted Payment"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:867
+msgid "Something went wrong creating your booking. Please try again."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:1011
+msgid "We couldn't confirm your payment"
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:1012
+msgid "If you completed payment, this can take a moment to confirm — please check back shortly, or contact us with your reference below."
+msgstr ""
+
+#: Frontend/MPWPB_Native_Checkout.php:1026
+msgid "Try again"
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:37
+msgid "PayPal is not configured. Please contact the site administrator."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:53
+msgid "Could not authenticate with PayPal."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:109
+msgid "PayPal order creation failed."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:119
+msgid "PayPal did not return an approval link."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:129
+msgid "Missing PayPal order reference."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:161
+msgid "PayPal capture failed."
+msgstr ""
+
+#: Frontend/MPWPB_Paypal_Gateway.php:186
+msgid "Could not confirm PayPal order status."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:86
+msgid "Close recurring booking editor"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:89
+msgid "Manage recurring booking"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:89
+#: Frontend/MPWPB_User_Dashboard.php:57
+msgid "Edit appointment"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:89
+msgid "Choose the date first, then an available time, then review or add services."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:91
+msgid "Editing steps"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:105
+msgid "Step 1"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:105
+msgid "Select a date"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:110
+msgid "No bookable dates are currently available."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:115
+msgid "Step 2"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:115
+msgid "Select an available time"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:115
+msgid "Change date"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:120
+msgid "Step 3"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:120
+msgid "Review and add services"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:120
+msgid "Change time"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:121
+msgid "Previously selected services remain checked. You may add another service or adjust quantities before updating."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:129
+#, php-format
+msgid "Quantity for %s"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:137
+msgid "Selected service subtotal"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:138
+#: Frontend/MPWPB_User_Dashboard.php:59
+msgid "Update appointment"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:149
+msgid "You do not have permission to manage this recurring booking."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:154
+msgid "This booking is not part of a recurring series."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:170
+msgid "That date is no longer available."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:195
+msgid "This appointment is no longer inside the online editing window."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:198
+msgid "This recurring series has reached its appointment limit."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:208
+msgid "Another appointment in this series already uses that date and time."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:226
+msgid "The appointment was added. Its balance is ready for payment."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:231
+msgid "The new selection costs less than the amount already paid. Please contact the administrator for a refund-assisted change."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:236
+#, php-format
+msgid "Recurring appointment updated by customer: %s"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:249
+msgid "Recurring appointment services updated by customer."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:252
+msgid "The appointment was updated. Please pay the new balance to confirm the added services."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:253
+msgid "The recurring appointment was updated successfully."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:272
+msgid "Choose a valid available date."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:277
+msgid "Choose a valid available time."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:280
+msgid "That time was just booked. Please choose another."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:298
+msgid "A selected service or quantity is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:339
+msgid "Recurring appointment added by customer."
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:404
+#: Frontend/MPWPB_Woocommerce.php:589
+#: Frontend/MPWPB_Woocommerce.php:614
+msgid "Price "
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:404
+#: Frontend/MPWPB_Woocommerce.php:603
+msgid "Date "
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:404
+#: Frontend/MPWPB_Woocommerce.php:604
+msgid "Time "
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:406
+msgid "Appointment "
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Account_Manager.php:413
+#, php-format
+msgid "Appointment %d"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:233
+msgid "Type:"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:237
+msgid "Occurrences:"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:242
+msgid "Discount:"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:249
+msgid "Scheduled Dates:"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:291
+#: templates/registration/date_time_select.php:146
+msgid "Recurring Type"
+msgstr ""
+
+#: Frontend/MPWPB_Recurring_Booking.php:292
+msgid "Occurrences"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:40
+msgid "Confirmation"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:42
+msgid "Booking progress"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:74
+msgid "View more!"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:102
+msgid "Service benefits"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:103
+msgid "Feature Highlights"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:104
+msgid "Everything that makes this service a great choice."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:106
+msgid "Close feature highlights"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:163
+msgid "Overview"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:173
+#: templates/registration/service_selection.php:54
+#: templates/registration/service_selection.php:55
+msgid "Details"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:239
+msgid "Bookings completed"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:244
+msgid "Typical slot length"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:248
+msgid "Services offered"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:281
+msgid "By appointment"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:302
+msgid "Service FAQ"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:366
+msgid "Our Past Work"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:367
+msgid "See the stunning results of our meticulous work."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:438
+#: Frontend/MPWPB_Static_Template.php:469
+msgid "Write a Review"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:444
+msgid "No reviews yet. Be the first to review this service!"
+msgstr ""
+
+#. translators: %s: login link
+#: Frontend/MPWPB_Static_Template.php:479
+#, php-format
+msgid "Please %s to leave a review."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:480
+msgid "log in"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:485
+msgid "You can write a review after booking this service."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:489
+msgid "Overall Rating"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:498
+msgid "Title (optional)"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:499
+msgid "Summarize your experience"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:502
+msgid "Your Review"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:503
+msgid "Tell us what you liked or what could be improved…"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:508
+msgid "Submit Review"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:680
+#: Frontend/MPWPB_Static_Template.php:685
+msgid "Review your reorder"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:682
+msgid "The original order did not store a base service. Its available extras were restored; choose a service and a new date and time to continue."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:683
+msgid "The original service is no longer available. Choose a current service and a new date and time to continue."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:686
+msgid "Available choices from the original order were restored. Some old choices are no longer available; review the selection and choose a new date and time."
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:688
+msgid "Reorder ready"
+msgstr ""
+
+#: Frontend/MPWPB_Static_Template.php:689
+msgid "Your previous choices were restored. Choose a new date and time to complete the reorder."
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:43
+msgid "Stripe is not configured. Please contact the site administrator."
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:61
+msgid "Deposit Payment for Booking"
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:69
+#: Frontend/MPWPB_Stripe_Gateway.php:116
+msgid "Stripe did not return a checkout URL."
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:107
+#: Frontend/MPWPB_User_Dashboard.php:504
+#: mp_global/class/MPWPB_Cancellation.php:184
+#: mp_global/class/MPWPB_Cancellation.php:210
+msgid "Booking"
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:126
+msgid "Stripe is not configured."
+msgstr ""
+
+#: Frontend/MPWPB_Stripe_Gateway.php:197
+msgid "Stripe request failed."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:49
+#: Frontend/MPWPB_User_Dashboard.php:499
+msgid "Loading booking details…"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:50
+msgid "Submitting request…"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:51
+#: Frontend/MPWPB_User_Dashboard.php:493
+msgid "Request booking cancellation"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:52
+msgid "Request recurring series cancellation"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:53
+#: Frontend/MPWPB_User_Dashboard.php:521
+msgid "Submit cancellation request"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:54
+msgid "Submit series cancellation request"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:55
+msgid "The cancellation request could not be submitted. Please try again."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:58
+#: Frontend/MPWPB_User_Dashboard.php:60
+msgid "Add appointment"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:61
+msgid "Saving changes…"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:62
+msgid "Loading available times…"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:63
+msgid "No available times remain for this date."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:64
+msgid "The recurring appointment could not be updated. Please try again."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:97
+msgid "View orders"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:98
+msgid "Review purchases and booking payments."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:102
+msgid "Manage addresses"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:103
+msgid "Update your billing and shipping details."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:107
+msgid "Account details"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:108
+msgid "Change your name, email, or password."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:116
+msgid "What would you like to do?"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:152
+msgid "My Bookings"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:233
+msgid "My Booking History"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:430
+msgid "Cancellation pending approval"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:433
+msgid "Request Cancellation"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:466
+msgid "Paid:"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:470
+msgid "Balance Due:"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:474
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:85
+msgid "Pay Balance"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:488
+msgid "Close cancellation dialog"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:492
+msgid "Cancellation request"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:494
+msgid "Your booking stays active until an administrator reviews and approves this request."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:511
+msgid "Why would you like to cancel?"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:512
+msgid "Please provide a short reason so the administrator can review your request."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:513
+msgid "This reason is shared with the administrator."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:517
+msgid "I understand that this is a request and my booking is not cancelled until it is approved."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:520
+msgid "Keep booking"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:591
+msgid "Manage your account settings, personal details, and security preferences."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:599
+msgid "Personal Information"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:619
+msgid "e.g., +1 (555) 234 5678"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:628
+msgid "Address Details"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:632
+msgid "Street Address"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:633
+msgid "e.g., 123 Industrial Way"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:637
+msgid "e.g., New York"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:645
+msgid "Security"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:650
+msgid "New Password"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:652
+msgid "Leave blank to keep your current password. Must be at least 8 characters."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:657
+msgid "Passwords must match exactly."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:670
+msgid "Preferences & Notes"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:671
+msgid "Describe your preferred service intervals, communication methods, or any special instructions..."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:694
+msgid "Account Summary"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:698
+msgid "Member Since"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:706
+msgid "View My Bookings"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:728
+msgid "You can request that we delete or anonymize the personal data we hold about you. An admin reviews and approves every request before anything is changed."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:732
+msgid "Your data request is pending admin review. You'll see an updated status here once it's resolved."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:737
+msgid "Your previous data request was reviewed and rejected. You may submit a new request below."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:741
+msgid "Your previous data request was approved and applied. You may submit a new request below if needed."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:750
+msgid "Your booking records stay (for our accounting/tax records), but we redact whichever fields you select below."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:753
+msgid "Delete customer profile"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:754
+msgid "Delete phone"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:755
+msgid "Delete address"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:756
+msgid "Delete notes"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:763
+msgid "All of your booking/order records and profile data are permanently deleted. Your site login itself is not affected."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:766
+msgid "Submit Data Request"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:819
+msgid "You must be logged in to do this."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:822
+msgid "This feature is not currently available."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:837
+msgid "Your data request has been submitted and is pending admin approval."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:949
+msgid "Your cancellation request was submitted. The booking remains active until an administrator approves it."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:962
+msgid "You do not have permission to view this booking."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:971
+#: mp_global/class/MPWPB_Cancellation.php:40
+msgid "A cancellation request is already awaiting review."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:972
+msgid "This booking is no longer eligible for online cancellation."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:993
+#, php-format
+msgid "%d recurring appointments"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:998
+#, php-format
+msgid "This request covers the entire recurring series. It must be submitted at least %d hour before the next appointment."
+msgid_plural "This request covers the entire recurring series. It must be submitted at least %d hours before the next appointment."
+msgstr[0] ""
+msgstr[1] ""
+
+#: Frontend/MPWPB_User_Dashboard.php:999
+#, php-format
+msgid "Cancellation requests must be submitted at least %d hour before the appointment."
+msgid_plural "Cancellation requests must be submitted at least %d hours before the appointment."
+msgstr[0] ""
+msgstr[1] ""
+
+#. translators: %s: new booking date/time
+#: Frontend/MPWPB_User_Dashboard.php:1032
+#, php-format
+msgid "Booking rescheduled by customer. New date/time: %s"
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:1119
+msgid "Password must be at least 8 characters long."
+msgstr ""
+
+#: Frontend/MPWPB_User_Dashboard.php:1122
+msgid "Passwords do not match."
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:53
+msgid "Manage Recurring"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:67
+msgid "Cancellation Pending"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:94
+msgid "Cancel Series"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:94
+msgid "Cancel Booking"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:142
+#, php-format
+msgid "Editing closes %d hour before the appointment."
+msgid_plural "Editing closes %d hours before the appointment."
+msgstr[0] ""
+msgstr[1] ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:143
+msgid "This appointment can no longer be edited online."
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:159
+msgid "Recurring booking"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:160
+msgid "Your appointment series"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:161
+#, php-format
+msgid "%d appointment is included in this order."
+msgid_plural "%d appointments are included in this order."
+msgstr[0] ""
+msgstr[1] ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:180
+msgid "Edit"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:182
+msgid "Editing closed"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:184
+msgid "Pay balance"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:190
+msgid "Paid across series"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:191
+msgid "Balance due"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:192
+msgid "Pay Outstanding Balance"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:196
+msgid "Add Appointment"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:198
+msgid "This series has reached the configured appointment limit. You can still edit eligible appointments and add services."
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:201
+msgid "Series cancellation pending approval"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:203
+msgid "Request Series Cancellation"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Account_Order_Actions.php:205
+msgid "Book This Service Again"
+msgstr ""
+
+#. translators: %s: checkout upload field label
+#: Frontend/MPWPB_Wc_Checkout_Fields_Helper.php:685
+#, php-format
+msgid "%s is a required field."
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Checkout_Fields_Helper.php:934
+msgid "No valid file found"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Checkout_Fields_Helper.php:940
+msgid "No file uploaded"
+msgstr ""
+
+#: Frontend/MPWPB_Wc_Staff_Account.php:92
+#: Frontend/MPWPB_Wc_Staff_Account.php:100
+#: Frontend/MPWPB_Wc_Staff_Account.php:109
+msgid "This page is only available to staff members."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:228
+msgid "This booking service is not available."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:236
+msgid "Please select at least one service."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:239
+msgid "The same service cannot be selected more than once."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:245
+msgid "The selected service or quantity is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:252
+msgid "The selected service category is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:261
+msgid "The selected booking date or time is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:265
+msgid "The recurring booking selection is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:268
+msgid "Please select one booking date and time."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:272
+msgid "One of the selected booking times is no longer available."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:286
+msgid "Extra services are not available for this booking."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:291
+msgid "An extra service or quantity is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:297
+msgid "The selected staff member is not available."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:305
+#: Frontend/MPWPB_Woocommerce.php:311
+msgid "The booking cart item is invalid."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:315
+msgid "A booking time in your cart is no longer available. Please choose another time."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:319
+msgid "The selected staff member is no longer available."
+msgstr ""
+
+#. translators: %s: booking coupon code.
+#: Frontend/MPWPB_Woocommerce.php:472
+#, php-format
+msgid "Booking coupon (%s)"
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:500
+msgid "Booking Details "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:607
+msgid "Duration "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:612
+msgid "Services Name "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:613
+msgid "Quantity "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:618
+msgid "Staff Name "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:621
+msgid "Coupon Applied "
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:622
+msgid "Discount "
+msgstr ""
+
+#. translators: 1: coupon code, 2: formatted discount amount
+#: Frontend/MPWPB_Woocommerce.php:742
+#, php-format
+msgid "Coupon \"%1$s\" applied — %2$s discount."
+msgstr ""
+
+#. translators: %s: amount charged as a deposit
+#: Frontend/MPWPB_Woocommerce.php:885
+#, php-format
+msgid "Deposit of %s paid at checkout."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:1094
+msgid "Services Name"
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:1109
+msgid "Selected Staff"
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:1249
+msgid "Online booking is currently unavailable because no payment method is configured. Please contact the site administrator."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:1260
+msgid "The booking could not be added. Please try again."
+msgstr ""
+
+#: Frontend/MPWPB_Woocommerce.php:1291
+msgid "The booking could not be added to the cart. Please try again."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:54
+msgid "Invalid coupon code."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:61
+msgid "This coupon is not yet valid."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:64
+msgid "This coupon has expired."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:70
+msgid "This coupon is not valid for the selected service(s)."
+msgstr ""
+
+#. translators: %s: minimum booking total required
+#: inc/MPWPB_Coupon_Validator.php:79
+#, php-format
+msgid "A minimum booking total of %s is required for this coupon."
+msgstr ""
+
+#. translators: %s: maximum booking total allowed
+#: inc/MPWPB_Coupon_Validator.php:86
+#, php-format
+msgid "This coupon only applies to bookings up to %s."
+msgstr ""
+
+#. translators: %d: minimum quantity required
+#: inc/MPWPB_Coupon_Validator.php:97
+#, php-format
+msgid "A minimum quantity of %d is required for this coupon."
+msgstr ""
+
+#. translators: %d: maximum quantity allowed
+#: inc/MPWPB_Coupon_Validator.php:104
+#, php-format
+msgid "This coupon only applies to a maximum quantity of %d."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:160
+msgid "This coupon requires a selected booking date/time."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:170
+msgid "This coupon is only valid on weekdays."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:173
+msgid "This coupon is only valid on weekends."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:177
+msgid "This coupon is not valid for the selected date."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:180
+msgid "This coupon cannot be used on the selected date."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:186
+msgid "This coupon is only valid for a specific time of day."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:192
+msgid "This coupon is only valid within a specific time range."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:208
+msgid "Please enter your email to apply this coupon."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:212
+msgid "This coupon is valid for guest checkout only."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:215
+msgid "This coupon requires a logged-in account."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:221
+msgid "This coupon is valid for first-time customers only."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:224
+msgid "This coupon is valid for returning customers only."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:240
+msgid "This coupon requires a specific staff member to be selected."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:244
+#: inc/MPWPB_Coupon_Validator.php:247
+msgid "This coupon is not valid with the selected staff member."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:257
+msgid "This coupon has reached its usage limit."
+msgstr ""
+
+#: inc/MPWPB_Coupon_Validator.php:264
+msgid "You have already used this coupon the maximum number of times."
+msgstr ""
+
+#: inc/MPWPB_Dependencies.php:142
+msgid "Loading..."
+msgstr ""
+
+#: inc/MPWPB_Dependencies.php:215
+msgid "Online booking is temporarily unavailable. Please contact us and we'll be glad to complete your booking."
+msgstr ""
+
+#: inc/MPWPB_Dependencies.php:216
+msgid "No payment method is configured. Activate WooCommerce (with a payment gateway) or set up a native payment method to accept bookings."
+msgstr ""
+
+#: inc/MPWPB_Dependencies.php:218
+msgid "Go to Payment Settings"
+msgstr ""
+
+#: inc/MPWPB_Dependencies.php:219
+msgid "The booking could not be completed. Please review your selection and try again."
+msgstr ""
+
+#: inc/MPWPB_Function.php:97
+msgid "Organizer"
+msgstr ""
+
+#: inc/MPWPB_Function.php:292
+msgid "10 min"
+msgstr ""
+
+#: inc/MPWPB_Function.php:293
+msgid "15 min"
+msgstr ""
+
+#: inc/MPWPB_Function.php:294
+msgid "30 min"
+msgstr ""
+
+#: inc/MPWPB_Function.php:295
+msgid "45 min"
+msgstr ""
+
+#: inc/MPWPB_Function.php:296
+#: inc/MPWPB_Function.php:344
+msgid "1 Hour"
+msgstr ""
+
+#: inc/MPWPB_Function.php:297
+msgid "1h 30m"
+msgstr ""
+
+#: inc/MPWPB_Function.php:298
+msgid "2 Hours"
+msgstr ""
+
+#: inc/MPWPB_Function.php:299
+msgid "3 Hours"
+msgstr ""
+
+#. translators: 1: whole hours, 2: leftover minutes
+#: inc/MPWPB_Function.php:340
+#, php-format
+msgid "%1$dh %2$dm"
+msgstr ""
+
+#. translators: %d: number of hours
+#: inc/MPWPB_Function.php:346
+#, php-format
+msgid "%d Hours"
+msgstr ""
+
+#. translators: %d: number of minutes
+#: inc/MPWPB_Function.php:349
+#, php-format
+msgid "%d min"
+msgstr ""
+
+#: inc/MPWPB_Layout.php:17
+msgid "Select"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:187
+msgid "Book Your Service"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:189
+msgid "Select Service"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:194
+#: templates/registration/next_date_time.php:50
+msgid "Proceed to Checkout"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:195
+msgid "Total Price"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:277
+msgid "Translation Settings"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:304
+msgid "Enable advanced translation for this service"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:311
+msgid "Translation Information"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:315
+msgid "When enabled, all service details will be registered for translation with WPML, Polylang, or other translation plugins."
+msgstr ""
+
+#: inc/MPWPB_Localization.php:318
+msgid "Translation Tips:"
+msgstr ""
+
+#: inc/MPWPB_Localization.php:322
+msgid "Use WPML String Translation or Polylang Strings to translate service names, categories, and other dynamic content."
+msgstr ""
+
+#: inc/MPWPB_Localization.php:326
+msgid "For Loco Translate, scan the plugin for translatable strings."
+msgstr ""
+
+#: inc/MPWPB_Localization.php:330
+msgid "Remember to translate both static text and dynamic content like service names."
+msgstr ""
+
+#: inc/MPWPB_Localization.php:341
+#, php-format
+msgid "Active Translation Plugin: %s"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:86
+msgid "Installing WooCommerce..."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:87
+msgid "Activating WooCommerce..."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:88
+#: inc/MPWPB_Woo_Installer.php:247
+msgid "WooCommerce activated successfully!"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:89
+msgid "Redirecting..."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:90
+msgid "Installation failed. Please install WooCommerce manually."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:91
+msgid "Activation failed. Please activate WooCommerce manually."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:103
+msgid "Activate WooCommerce"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:104
+msgid "Install & Activate WooCommerce"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:127
+msgid "WooCommerce Required"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:129
+msgid "Service Booking Manager requires WooCommerce to manage service bookings, payments, and orders. Please install and activate WooCommerce to continue."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:138
+msgid "Service booking & payments"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:144
+msgid "Order management"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:150
+msgid "Customer registration"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:171
+msgid "Install Manually"
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:179
+msgid "WooCommerce is free, open-source, and trusted by millions of stores worldwide."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:190
+msgid "You do not have permission to install plugins."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:228
+msgid "Installation failed."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:231
+msgid "WooCommerce installed successfully."
+msgstr ""
+
+#: inc/MPWPB_Woo_Installer.php:238
+msgid "You do not have permission to activate plugins."
+msgstr ""
+
+#: MPWPB_Plugin.php:48
+msgid "Service Staffs"
+msgstr ""
+
+#: mp_global/class/MPWPB_Booking_History.php:134
+#: mp_global/class/MPWPB_Cancellation.php:37
+msgid "This booking is already cancelled."
+msgstr ""
+
+#: mp_global/class/MPWPB_Booking_History.php:139
+msgid "This booking can no longer be cancelled online -- the cancellation window has passed."
+msgstr ""
+
+#: mp_global/class/MPWPB_Booking_History.php:165
+msgid "A cancelled booking cannot be rescheduled."
+msgstr ""
+
+#: mp_global/class/MPWPB_Booking_History.php:170
+msgid "This booking can no longer be rescheduled online -- the reschedule window has passed."
+msgstr ""
+
+#: mp_global/class/MPWPB_Booking_Notes.php:237
+msgid "Please enter a message."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:31
+msgid "Invalid booking."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:34
+msgid "You do not have permission to cancel this booking."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:43
+msgid "This booking can no longer be cancelled online because the cancellation window has passed."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:46
+msgid "Please provide a short reason for your cancellation request."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:64
+#, php-format
+msgid "Customer requested cancellation. Reason: %s"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:76
+#: mp_global/class/MPWPB_Cancellation.php:122
+msgid "This cancellation request has already been reviewed."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:85
+msgid "Cancellation request approved by administrator."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:87
+#, php-format
+msgid "Customer reason: %s"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:90
+#, php-format
+msgid "Administrator note: %s"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:126
+msgid "Customer cancellation request rejected by administrator."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:183
+msgid "A customer submitted a booking cancellation request."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:192
+msgid "Reason"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:195
+msgid "Review cancellation request"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:197
+#, php-format
+msgid "Cancellation request for booking #%d"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:197
+msgid "New cancellation request"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:206
+msgid "approved"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:206
+msgid "not approved"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:209
+#, php-format
+msgid "Hello %s, your cancellation request has been %s."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:214
+msgid "Decision"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:218
+msgid "Administrator note:"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:220
+msgid "The booking and its associated order are now cancelled."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:220
+msgid "Your booking remains active. Please contact us if you need assistance."
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:222
+#, php-format
+msgid "Booking #%d cancellation approved"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:223
+#, php-format
+msgid "Booking #%d cancellation request update"
+msgstr ""
+
+#: mp_global/class/MPWPB_Cancellation.php:224
+msgid "Cancellation request update"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Layout.php:38
+#: mp_global/class/MPWPB_Custom_Layout.php:158
+#: mp_global/class/MPWPB_Custom_Layout.php:159
+msgid "Load More"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Layout.php:50
+msgid "GoTO Previous Page"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Layout.php:70
+msgid "GoTO Next Page"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Layout.php:158
+msgid "Less More"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Slider.php:60
+msgid "View All"
+msgstr ""
+
+#: mp_global/class/MPWPB_Custom_Slider.php:60
+msgid "Images"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:626
+#: templates/registration/date_time_select.php:138
+msgid "Monday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:627
+#: templates/registration/date_time_select.php:139
+msgid "Tuesday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:628
+#: templates/registration/date_time_select.php:140
+msgid "Wednesday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:629
+#: templates/registration/date_time_select.php:141
+msgid "Thursday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:630
+#: templates/registration/date_time_select.php:142
+msgid "Friday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:631
+#: templates/registration/date_time_select.php:143
+msgid "Saturday"
+msgstr ""
+
+#: mp_global/class/MPWPB_Global_Function.php:632
+#: templates/registration/date_time_select.php:137
+msgid "Sunday"
+msgstr ""
+
+#. translators: %s: formatted discount amount, e.g. "$15"
+#: mp_global/class/MPWPB_Happy_Hours_Helper.php:111
+#, php-format
+msgid "%s off"
+msgstr ""
+
+#. translators: %s: discount percentage, e.g. "20"
+#: mp_global/class/MPWPB_Happy_Hours_Helper.php:115
+#, php-format
+msgid "%s%% off"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:140
+msgid "You do not have permission to pay this balance."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:174
+#: mp_global/class/MPWPB_Partial_Payment.php:392
+msgid "Pay in Full"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:179
+#: mp_global/class/MPWPB_Partial_Payment.php:393
+msgid "Flexible"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:180
+#: mp_global/class/MPWPB_Partial_Payment.php:394
+msgid "Pay Deposit"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:181
+#: mp_global/class/MPWPB_Partial_Payment.php:395
+msgid "today"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:214
+msgid "Partial payment is not enabled."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:233
+#: mp_global/class/MPWPB_Partial_Payment.php:249
+msgid "This item does not support a deposit."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:490
+msgid "Enter an amount greater than zero."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:494
+#: mp_global/class/MPWPB_Partial_Payment.php:560
+msgid "This booking has no outstanding balance."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:497
+msgid "That amount is more than the remaining balance due."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:529
+msgid "Payment recorded by admin."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:564
+msgid "No order is associated with this booking."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:582
+#: mp_global/class/MPWPB_Partial_Payment.php:630
+msgid "The original order could not be found."
+msgstr ""
+
+#. translators: %s: original order number
+#: mp_global/class/MPWPB_Partial_Payment.php:606
+#, php-format
+msgid "Balance Payment — Order #%s"
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:626
+msgid "Custom Payment checkout is not available."
+msgstr ""
+
+#. translators: %s: balance order number
+#: mp_global/class/MPWPB_Partial_Payment.php:677
+#, php-format
+msgid "Balance paid online — Order #%s."
+msgstr ""
+
+#: mp_global/class/MPWPB_Partial_Payment.php:696
+msgid "Balance paid online."
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:23
+#: mp_global/class/MPWPB_Select_Icon_image.php:26
+msgid "Add Icon"
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:30
+#: mp_global/class/MPWPB_Select_Icon_image.php:152
+msgid "Remove Icon"
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:43
+msgid "Select Icon"
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:46
+msgid "Search icon by name...."
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:62
+msgid "All Icon"
+msgstr ""
+
+#: mp_global/class/MPWPB_Select_Icon_image.php:86
+msgid "No icons match your search."
+msgstr ""
+
+#: mp_global/class/MPWPB_Setting_API.php:273
+msgid "Choose File"
+msgstr ""
+
+#: mp_global/class/MPWPB_Tax_Helper.php:56
+msgid "Reduced Rate"
+msgstr ""
+
+#: mp_global/class/MPWPB_Tax_Helper.php:57
+msgid "Zero Rate"
+msgstr ""
+
+#: mp_global/class/MPWPB_Tax_Helper.php:86
+msgid "Tax"
+msgstr ""
+
+#: templates/layout/coupon_list.php:33
+msgid "Flat"
+msgstr ""
+
+#: templates/layout/coupon_list.php:35
+msgid "100% OFF (Free)"
+msgstr ""
+
+#: templates/layout/coupon_list.php:63
+msgid "Expired"
+msgstr ""
+
+#: templates/layout/coupon_list.php:69
+#: templates/layout/coupon_list.php:150
+msgid "Inactive"
+msgstr ""
+
+#: templates/layout/coupon_list.php:72
+#: templates/layout/coupon_list.php:91
+#: templates/layout/coupon_list.php:152
+#: templates/layout/service_list.php:295
+msgid "Trash"
+msgstr ""
+
+#: templates/layout/coupon_list.php:90
+msgid "Duplicate Coupon"
+msgstr ""
+
+#: templates/layout/coupon_list.php:111
+msgid "Create and manage booking discount coupons"
+msgstr ""
+
+#: templates/layout/coupon_list.php:119
+msgid "Total Coupons"
+msgstr ""
+
+#: templates/layout/coupon_list.php:133
+msgid "Total Redemptions"
+msgstr ""
+
+#: templates/layout/coupon_list.php:143
+msgid "Coupon Listings"
+msgstr ""
+
+#: templates/layout/coupon_list.php:156
+msgid "Search coupons…"
+msgstr ""
+
+#: templates/layout/service_list.php:112
+msgid "Restore"
+msgstr ""
+
+#: templates/layout/service_list.php:114
+msgid "Permanently delete this service? This cannot be undone."
+msgstr ""
+
+#: templates/layout/service_list.php:115
+msgid "Delete Permanently"
+msgstr ""
+
+#: templates/layout/service_list.php:119
+msgid "Duplicate Post "
+msgstr ""
+
+#: templates/layout/service_list.php:229
+msgid "Service Management"
+msgstr ""
+
+#: templates/layout/service_list.php:230
+msgid "Manage your services and track performance"
+msgstr ""
+
+#: templates/layout/service_list.php:248
+msgid "Active Clients"
+msgstr ""
+
+#: templates/layout/service_list.php:250
+#: templates/layout/service_list.php:265
+msgid "This month"
+msgstr ""
+
+#: templates/layout/service_list.php:257
+msgid "Monthly Revenue"
+msgstr ""
+
+#: templates/layout/service_list.php:272
+msgid "Upcoming Bookings"
+msgstr ""
+
+#: templates/layout/service_list.php:274
+msgid "Next 7 days"
+msgstr ""
+
+#: templates/layout/service_list.php:285
+msgid "Service Listings"
+msgstr ""
+
+#: templates/layout/service_list.php:286
+msgid "Manage all your services in one place"
+msgstr ""
+
+#: templates/layout/service_list.php:303
+msgid "Search services..."
+msgstr ""
+
+#: templates/layout/service_list.php:315
+msgid "Shortcode"
+msgstr ""
+
+#: templates/layout/service_list.php:317
+msgid "Popular Services"
+msgstr ""
+
+#. translators: 1: number of services shown, 2: total number of services
+#: templates/layout/service_list.php:332
+#, php-format
+msgid "Showing 1 to %1$d of %2$d entries"
+msgstr ""
+
+#: templates/registration/category_selection.php:125
+#: templates/registration/extra_services.php:48
+#: templates/registration/service_selection.php:54
+msgid "Close Details"
+msgstr ""
+
+#: templates/registration/category_selection.php:169
+#: templates/registration/category_selection.php:170
+#: templates/registration/extra_services.php:68
+#: templates/registration/extra_services.php:70
+#: templates/registration/service_selection.php:98
+#: templates/registration/service_selection.php:99
+msgid "Add"
+msgstr ""
+
+#: templates/registration/category_selection.php:169
+#: templates/registration/extra_services.php:68
+#: templates/registration/service_selection.php:98
+msgid "Added"
+msgstr ""
+
+#: templates/registration/category_selection.php:231
+#: templates/registration/category_selection.php:280
+msgid "Price Start At:"
+msgstr ""
+
+#: templates/registration/category_selection_static.php:69
+msgid "Tap to add"
+msgstr ""
+
+#: templates/registration/category_selection_static.php:78
+msgid "Our services"
+msgstr ""
+
+#: templates/registration/category_selection_static.php:79
+msgid "Tap a service to start booking. You can add more inside."
+msgstr ""
+
+#: templates/registration/date_time_select.php:85
+msgid "Choose Date"
+msgstr ""
+
+#: templates/registration/date_time_select.php:105
+msgid "Choose Time"
+msgstr ""
+
+#: templates/registration/date_time_select.php:118
+msgid "Date not available"
+msgstr ""
+
+#: templates/registration/date_time_select.php:124
+msgid "Recurring Booking Options"
+msgstr ""
+
+#: templates/registration/date_time_select.php:132
+msgid "Enable Recurring Booking"
+msgstr ""
+
+#: templates/registration/date_time_select.php:148
+msgid "Select Recurring Type"
+msgstr ""
+
+#: templates/registration/date_time_select.php:172
+msgid "Number of Occurrences"
+msgstr ""
+
+#: templates/registration/date_time_select.php:175
+msgid "Maximum allowed:"
+msgstr ""
+
+#: templates/registration/date_time_select.php:180
+msgid "Discount Applied:"
+msgstr ""
+
+#: templates/registration/date_time_select.php:185
+msgid "Recurring Dates"
+msgstr ""
+
+#: templates/registration/date_time_select.php:214
+msgid "Selected Date & Time"
+msgstr ""
+
+#: templates/registration/date_time_select.php:219
+msgid "Booking Total"
+msgstr ""
+
+#: templates/registration/extra_services.php:17
+msgid "Choose Extra Features (Optional)"
+msgstr ""
+
+#: templates/registration/next_date_time.php:35
+#: templates/registration/next_service.php:14
+#: templates/registration/static_registration.php:215
+#: templates/registration/summary_left.php:86
+#: templates/themes/default.php:170
+msgid "Total :"
+msgstr ""
+
+#: templates/registration/next_date_time.php:43
+#: templates/registration/next_date_time.php:49
+msgid "Please Select Date & Time"
+msgstr ""
+
+#: templates/registration/next_date_time.php:44
+msgid "Next Staff Member"
+msgstr ""
+
+#: templates/registration/next_service.php:15
+msgid "Please Select"
+msgstr ""
+
+#: templates/registration/next_service.php:16
+msgid "Next Date & Time"
+msgstr ""
+
+#: templates/registration/static_registration.php:50
+msgid "Select Service & Confirm Booking"
+msgstr ""
+
+#: templates/registration/static_registration.php:55
+msgid "Secure Payment Protection"
+msgstr ""
+
+#: templates/registration/static_registration.php:59
+msgid "Free Rescheduling up to 24h"
+msgstr ""
+
+#: templates/registration/static_registration.php:98
+msgid "Make Service Booking"
+msgstr ""
+
+#: templates/registration/static_registration.php:123
+#: templates/themes/default.php:72
+msgid "All Category"
+msgstr ""
+
+#: templates/registration/static_registration.php:133
+msgid "Your services"
+msgstr ""
+
+#: templates/registration/static_registration.php:134
+msgid "Tick services from any category — use the −/+ control to set quantity."
+msgstr ""
+
+#: templates/registration/static_registration.php:146
+#: templates/themes/default.php:89
+msgid "Booking checkout"
+msgstr ""
+
+#: templates/registration/static_registration.php:261
+#: templates/themes/default.php:206
+msgid "Continue :"
+msgstr ""
+
+#: templates/registration/summary_left.php:17
+msgid "Cart Summary"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:20
+msgid "This time slot is currently fully booked. Join our waiting list to be notified if a spot becomes available."
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:30
+msgid "Your Name"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:32
+msgid "Enter your full name"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:37
+msgid "Your Email"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:39
+msgid "Enter your email address"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:44
+msgid "Your Phone"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:46
+msgid "Enter your phone number"
+msgstr ""
+
+#: templates/registration/waiting_list_modal.php:60
+msgid "Your information will only be used to notify you about availability."
+msgstr ""
+
+#: templates/themes/default.php:65
+msgid "Select Service Type"
+msgstr ""
+
+#: templates/themes/default.php:66
+msgid "Choose the perfect wash for your vehicle"
+msgstr ""

--- a/wpml-config.xml
+++ b/wpml-config.xml
@@ -1,0 +1,103 @@
+<wpml-config>
+	<!--
+		WPML integration for Service Booking Manager.
+
+		Three separate things have to be declared before a booking page can be
+		fully translated, and WPML cannot guess any of them:
+
+		  1. custom-types  - makes each service translatable, so WPML offers a
+		                     "+" next to it and keeps the translations linked.
+		  2. taxonomies    - the same for service categories.
+		  3. admin-texts   - wording an admin typed into the plugin's own
+		                     settings screens. That lives in wp_options, not in
+		                     a post, so it is invisible to WPML until it is
+		                     listed here.
+
+		Strings that come from the plugin's code (buttons, labels, "Choose
+		Date", "Closed", ...) are NOT listed here. Those are gettext strings,
+		translated from languages/service-booking-manager.pot with WPML String
+		Translation's "Theme and plugins localization" or with Loco Translate.
+	-->
+
+	<custom-types>
+		<custom-type translate="1">mpwpb_item</custom-type>
+	</custom-types>
+
+	<taxonomies>
+		<taxonomy translate="1">mpwpb_category</taxonomy>
+	</taxonomies>
+
+	<custom-fields>
+		<!--
+			"copy" = one value shared by every language.
+
+			These are structural: dates, capacity, off days, slot length,
+			templates, the link to the hidden WooCommerce product. A translated
+			service has to book exactly the same slots against exactly the same
+			stock as its original – if these diverged per language, the Dutch
+			and English versions of one service would each hold their own
+			availability and the same seat could be sold twice.
+		-->
+		<custom-field action="copy">mpwpb_date_type</custom-field>
+		<custom-field action="copy">mpwpb_repeated_start_date</custom-field>
+		<custom-field action="copy">mpwpb_repeated_after</custom-field>
+		<custom-field action="copy">mpwpb_active_days</custom-field>
+		<custom-field action="copy">mpwpb_particular_dates</custom-field>
+		<custom-field action="copy">mpwpb_off_days</custom-field>
+		<custom-field action="copy">mpwpb_off_dates</custom-field>
+		<custom-field action="copy">mpwpb_default_start_time</custom-field>
+		<custom-field action="copy">mpwpb_default_end_time</custom-field>
+		<custom-field action="copy">mpwpb_time_slot_length</custom-field>
+		<custom-field action="copy">mpwpb_capacity_per_session</custom-field>
+		<custom-field action="copy">mpwpb_template</custom-field>
+		<custom-field action="copy">mpwpb_staff_member_add</custom-field>
+		<custom-field action="copy">mpwpb_selected_staff_ids</custom-field>
+		<custom-field action="copy">mpwpb_enable_waiting_list</custom-field>
+		<custom-field action="copy">mpwpb_max_waiting_list</custom-field>
+		<custom-field action="copy">mpwpb_enable_recurring</custom-field>
+		<custom-field action="copy">mpwpb_recurring_types</custom-field>
+		<custom-field action="copy">mpwpb_max_recurring_count</custom-field>
+		<custom-field action="copy">mpwpb_recurring_discount</custom-field>
+		<custom-field action="copy">mpwpb_extra_service_active</custom-field>
+		<custom-field action="copy">mpwpb_use_sub_category</custom-field>
+		<custom-field action="copy">mpwpb_show_category_status</custom-field>
+		<custom-field action="copy">mpwpb_display_slider</custom-field>
+		<custom-field action="copy">mpwpb_slider_images</custom-field>
+		<custom-field action="copy">link_wc_product</custom-field>
+		<custom-field action="copy">check_if_run_once</custom-field>
+
+		<!--
+			"translate" = the translator gets a field for it in WPML's editor.
+			These hold wording the customer actually reads. The service and
+			extra-service fields are arrays of rows; WPML exposes the text
+			inside them (the names) while the prices stay as entered.
+		-->
+		<custom-field action="translate">mpwpb_service</custom-field>
+		<custom-field action="translate">mpwpb_extra_service</custom-field>
+		<custom-field action="translate">mpwpb_category_service</custom-field>
+		<custom-field action="translate">mpwpb_sub_category_service</custom-field>
+		<custom-field action="translate">mpwpb_category_infos</custom-field>
+		<custom-field action="translate">mpwpb_shortcode_title</custom-field>
+		<custom-field action="translate">mpwpb_shortcode_sub_title</custom-field>
+		<custom-field action="translate">mpwpb_sub_category_text</custom-field>
+		<custom-field action="translate">mpwpb_faq</custom-field>
+		<custom-field action="translate">mpwpb_waiting_list_email_subject</custom-field>
+		<custom-field action="translate">mpwpb_waiting_list_email_body</custom-field>
+	</custom-fields>
+
+	<admin-texts>
+		<!--
+			Wording typed into Settings > General. Once listed, these appear
+			under WPML > String Translation with the context
+			"admin_texts_mpwpb_general_settings" and can be given a value per
+			language. Slugs and icons are deliberately not included: a slug is
+			a URL fragment, and WPML handles per-language slugs separately.
+		-->
+		<key name="mpwpb_general_settings">
+			<key name="label" />
+			<key name="category_label" />
+			<key name="organizer_label" />
+			<key name="category_text" />
+		</key>
+	</admin-texts>
+</wpml-config>


### PR DESCRIPTION
Neither piece existed, which is why a multilingual site could not get a booking page fully into its own language however hard the owner tried.

No POT was shipped at all -- only a stray bn_BD translation, with no template behind it. WPML String Translation and Loco Translate both start from the POT, so there was nothing for a translator to open and no list of the plugin's strings anywhere. Generated with wp i18n make-pot: 3307 strings.

No wpml-config.xml either, so WPML was never told that:

  - services are translatable. Without the declaration WPML does not offer the "+" next to a service at all, so a second language version simply could not be created.
  - service categories are translatable.
  - the wording an admin typed into Settings > General is text. That lives in wp_options rather than in a post, so WPML cannot discover it on its own and it stayed in one language permanently.

Per-service fields are declared explicitly rather than left to WPML's default. Everything structural -- dates, capacity, off days, slot length, the link to the hidden WooCommerce product -- is marked "copy", so a translated service always sells the same slots from the same stock as its original. Left translatable, the Dutch and English versions of one service would each keep their own availability and the same seat could be sold twice.